### PR TITLE
Fix for the get_review_ids function and Jenkins job extra parameter

### DIFF
--- a/Mesos/cron-jobs/mesos-nightly-build.sh
+++ b/Mesos/cron-jobs/mesos-nightly-build.sh
@@ -17,6 +17,6 @@ LOG_FILE=$(realpath "$LOGS_DIR/cron-mesos-nightly-build.log") || (echo "ERROR: F
 JOB_NAME="mesos-nightly-build"
 ps aux | grep -v " grep " | grep "$PYTHON_SCRIPT" | grep -q "$JOB_NAME" && echo -e "$(date +%m-%d-%y-%T) - The script $PYTHON_SCRIPT for $JOB_NAME is already running\n" >> $LOG_FILE && exit 0
 
-python $PYTHON_SCRIPT -s "$GEARMAN_SERVERS_LIST" -j 'mesos-nightly-build' --params '{"BRANCH": "master"}' 2>&1 >> $LOG_FILE
+python $PYTHON_SCRIPT -s "$GEARMAN_SERVERS_LIST" -j 'mesos-nightly-build' --params '{"BRANCH": "master", "MESOS_JENKINS_BRANCH": "master"}' 2>&1 >> $LOG_FILE
 
 echo -e "\n" >> $LOG_FILE

--- a/Mesos/cron-jobs/verify-review-requests.sh
+++ b/Mesos/cron-jobs/verify-review-requests.sh
@@ -19,6 +19,6 @@ LOG_FILE=$(realpath "$LOGS_DIR/cron-mesos-verify-review-requests.log") || (echo 
 ps aux | grep -v " grep " | grep -q "$PYTHON_SCRIPT" && echo -e "$(date +%m-%d-%y-%T) - The script $PYTHON_SCRIPT is already running\n" >> $LOG_FILE && exit 0
 
 python $PYTHON_SCRIPT -u "$REVIEWBOARD_USER" -p "$REVIEWBOARD_USER_PASSWORD" \
-                      gearman -s "$GEARMAN_SERVERS_LIST" -j 'mesos-build' --params '{"BRANCH": "master"}' 2>&1 >> $LOG_FILE
+                      gearman -s "$GEARMAN_SERVERS_LIST" -j 'mesos-build' --params '{"BRANCH": "master", "MESOS_JENKINS_BRANCH": "master"}' 2>&1 >> $LOG_FILE
 
 echo -e "\n" >> $LOG_FILE

--- a/Mesos/start-windows-build.ps1
+++ b/Mesos/start-windows-build.ps1
@@ -157,11 +157,14 @@ function Copy-CmakeBuildLogs {
 function Add-ReviewBoardPatch {
     Write-Output "Applying Reviewboard patch(es) over Mesos $Branch branch"
     $tempFile = Join-Path $env:TEMP "mesos_dependent_review_ids"
-
     Start-MesosCIProcess -ProcessPath "python.exe" -StdoutFileName "get-review-ids-stdout.log" -StderrFileName "get-review-ids-stderr.log" `
                          -ArgumentList @("$PSScriptRoot\utils\get-review-ids.py", "-r", $ReviewID, "-o", $tempFile) `
                          -BuildErrorMessage "Failed to get dependent review IDs for the current patch."
     $reviewIDs = Get-Content $tempFile
+    if(!$reviewIDs) {
+        Write-Output "There aren't any reviews to be applied"
+        return
+    }
     Write-Output "Patches IDs that need to be applied: $reviewIDs"
     foreach($id in $reviewIDs) {
         Write-Output "Applying patch ID: $id"

--- a/Spartan/cron-jobs/spartan-nightly-build.sh
+++ b/Spartan/cron-jobs/spartan-nightly-build.sh
@@ -17,6 +17,6 @@ LOG_FILE=$(realpath "$LOGS_DIR/cron-spartan-nightly-build.log") || (echo "ERROR:
 JOB_NAME="spartan-nightly-build"
 ps aux | grep -v " grep " | grep "$PYTHON_SCRIPT" | grep -q "$JOB_NAME" && echo -e "$(date +%m-%d-%y-%T) - The script $PYTHON_SCRIPT for $JOB_NAME is already running\n" >> $LOG_FILE && exit 0
 
-python $PYTHON_SCRIPT -s "$GEARMAN_SERVERS_LIST" -j "$JOB_NAME" --params '{"BRANCH": "master"}' 2>&1 >> $LOG_FILE
+python $PYTHON_SCRIPT -s "$GEARMAN_SERVERS_LIST" -j "$JOB_NAME" --params '{"BRANCH": "master", "MESOS_JENKINS_BRANCH": "master"}' 2>&1 >> $LOG_FILE
 
 echo -e "\n" >> $LOG_FILE


### PR DESCRIPTION
This PR includes:

- Fix for an issue with the function 'get_review_ids' that should return the review ids to be applied for a particular review request. It was missing an extra check to verify if the review request is already submitted.
- Add `MESOS_JENKINS_BRANCH` extra parameter when triggering Jenkins jobs.