### PR TITLE
Change how ACS Engine is updated

### DIFF
--- a/DCOS/utils/install-latest-stable-acs-engine.sh
+++ b/DCOS/utils/install-latest-stable-acs-engine.sh
@@ -3,21 +3,22 @@ set -e
 
 REPO_URL="https://github.com/Azure/acs-engine"
 REPO_DIR="/tmp/acs-engine"
+GIT_RELEASE_BASE_URL="https://github.com/Azure/acs-engine/releases/download"
 
 # Get the current ACS Engine (or set the variable to "" if the acs-engine is not installed)
 which acs-engine > /dev/null && ACS_VERSION=$(acs-engine version | grep "Version" | awk '{print $2}') || ACS_VERSION=""
 
+rm -rf $REPO_DIR
+git clone $REPO_URL $REPO_DIR
+pushd $REPO_DIR
+
 if [[ $ACS_VERSION != "" ]]; then
-    echo "Detected installed ACS Engine version: $ACS_VERSION"
-    rm -rf $REPO_DIR
-    echo "Checking if there is a newer stable ACS Engine"
-    git clone $REPO_URL $REPO_DIR &> /dev/null
-    pushd $REPO_DIR &> /dev/null
+    echo "Detected installed ACS Engine version: $ACS_VERSION. Checking if there is a newer stable ACS Engine"
     ACS_LATEST_STABLE_VERSION=$(git tag --sort=-taggerdate | head -1)
-    popd &> /dev/null
-    rm -rf $REPO_DIR
     if [[ "$ACS_VERSION" = "$ACS_LATEST_STABLE_VERSION" ]]; then
         echo "ACS Engine is already updated to the latest stable version: $ACS_VERSION"
+        popd
+        rm -rf $REPO_DIR
         exit 0
     fi
     echo "New ACS Engine version available: $ACS_LATEST_STABLE_VERSION"
@@ -25,20 +26,31 @@ fi
 
 echo "Installing ACS Engine latest stable"
 
-export GOPATH="/tmp/golang"
-export PATH="$PATH:/usr/local/go/bin:$GOPATH/bin"
-
-go get -v github.com/Azure/acs-engine
-
-pushd $GOPATH/src/github.com/Azure/acs-engine
 if [[ -z $ACS_LATEST_STABLE_VERSION ]]; then
     ACS_LATEST_STABLE_VERSION=$(git tag --sort=-taggerdate | head -1)
 fi
-git checkout $ACS_LATEST_STABLE_VERSION
-make bootstrap
-make build
-sudo mv ./bin/acs-engine /usr/local/bin/acs-engine
 popd
-rm -rf $GOPATH
+rm -rf $REPO_DIR
+
+RELEASE_URL="${GIT_RELEASE_BASE_URL}/${ACS_LATEST_STABLE_VERSION}/acs-engine-${ACS_LATEST_STABLE_VERSION}-linux-amd64.tar.gz"
+OUT_FILE="acs-engine-${ACS_LATEST_STABLE_VERSION}-linux-amd64.tar.gz"
+
+cd /tmp
+EXIT_CODE=0
+OUTPUT=$(wget $RELEASE_URL -O $OUT_FILE 2>&1) || EXIT_CODE=1
+if [[ $EXIT_CODE -ne 0 ]]; then
+    if echo $OUTPUT | grep -q "ERROR 404"; then
+        echo "There isn't a git download URL for the new version: $ACS_LATEST_STABLE_VERSION. Will still use ACS Engine version: $ACS_VERSION"
+        exit 0
+    else
+        echo $OUTPUT
+        exit 1
+    fi
+fi
+
+tar xzf $OUT_FILE
+EXTRACT_DIR="acs-engine-${ACS_LATEST_STABLE_VERSION}-linux-amd64"
+sudo mv $EXTRACT_DIR/acs-engine /usr/local/bin/acs-engine
+rm -rf $EXTRACT_DIR $OUT_FILE
 
 echo "Finished installing ACS Engine version: $ACS_LATEST_STABLE_VERSION"


### PR DESCRIPTION
Instead of building from scratch the ACS Engine everytime a new
stable tag is released, we now use the git download URLs to download
the new stable binaries.