### PR TITLE
Disable SSL for the Mesos nightly builds and add RS3 DC/OS deployments support

### DIFF
--- a/DCOS/acs-engine-dcos-deploy.sh
+++ b/DCOS/acs-engine-dcos-deploy.sh
@@ -106,9 +106,17 @@ acs-engine generate --output-directory $DCOS_DEPLOY_DIR $ACS_RENDERED_TEMPLATE
 rm -rf ./translations # Left-over after running 'acs-engine generate'
 rm $ACS_RENDERED_TEMPLATE
 
+
 # Deploy the DCOS with Mesos environment
 DEPLOY_TEMPLATE_FILE="$DCOS_DEPLOY_DIR/azuredeploy.json"
 DEPLOY_PARAMS_FILE="$DCOS_DEPLOY_DIR/azuredeploy.parameters.json"
+
+# TODO(ibalutoiu): Remove these sed calls once the Windows version can be directly 
+#                  specified in the ACS template. This is temporary workaround
+#                  to enable RS3 deployments.
+sed -i 's|    "agentWindowsOffer": "WindowsServer",|    "agentWindowsOffer": "WindowsServerSemiAnnual",|g' $DEPLOY_TEMPLATE_FILE
+sed -i 's|    "agentWindowsSku": "2016-Datacenter-with-Containers",|    "agentWindowsSku": "Datacenter-Core-1709-with-Containers-smalldisk",|g' $DEPLOY_TEMPLATE_FILE
+
 azure_cli_login
 az group create -l "$AZURE_REGION" -n "$AZURE_RESOURCE_GROUP" -o table
 echo "Started the DCOS deployment"

--- a/DCOS/spartan-agent-setup.ps1
+++ b/DCOS/spartan-agent-setup.ps1
@@ -132,11 +132,17 @@ function New-SpartanWindowsAgent {
         "service_binary" = $erlBinary
         "service_arguments" = $spartanArguments
         "log_dir" = $SPARTAN_LOG_DIR
+        "env_vars" = @(
+            @{
+                'name' = 'MASTER_SOURCE'
+                'value' = 'exhibitor'
+            },
+            @{
+                'name' = 'EXHIBITOR_ADDRESS'
+                'value' = $MasterAddress[0]
+            }
+        )
     }
-    $env:MASTER_SOURCE = "exhibitor"
-    Start-ExternalCommand { setx.exe /M MASTER_SOURCE "exhibitor" } -ErrorMessage "Failed to set the Spartan MASTER_SOURCE system environment variable"
-    $env:EXHIBITOR_ADDRESS = $MasterAddress[0]
-    Start-ExternalCommand { setx.exe /M EXHIBITOR_ADDRESS $MasterAddress[0] } -ErrorMessage "Failed to set the Spartan EXHIBITOR_ADDRESS system environment variable"
     Start-RenderTemplate -TemplateFile "$TEMPLATES_DIR\windows-service.xml" -Context $context -OutFile "$SPARTAN_SERVICE_DIR\spartan-service.xml"
     $serviceWapper = Join-Path $SPARTAN_SERVICE_DIR "spartan-service.exe"
     Invoke-WebRequest -UseBasicParsing -Uri $SERVICE_WRAPPER_URL -OutFile $serviceWapper

--- a/DCOS/templates/windows-service.xml
+++ b/DCOS/templates/windows-service.xml
@@ -15,4 +15,7 @@
     <sizeThreshold>10240</sizeThreshold>
     <keepFiles>8</keepFiles>
   </log>
+{% for var in env_vars -%}
+  <env name="{{ var.name }}" value="{{ var.value }}"/>
+{% endfor -%}
 </configuration>

--- a/Mesos/jenkins-jobs/mesos-build.ps1
+++ b/Mesos/jenkins-jobs/mesos-build.ps1
@@ -3,7 +3,7 @@ $ErrorActionPreference = 'Stop'
 $paramsFile = Join-Path $env:WORKSPACE "mesos-build-parameters.txt"
 $consoleLogFile = Join-Path $env:WORKSPACE "mesos-build-${env:BRANCH}-${env:BUILD_NUMBER}.log"
 $windowsBuildScript = (Resolve-Path "$PSScriptRoot\..\start-windows-build.ps1").Path
-& "$windowsBuildScript" -Branch $env:BRANCH -CommitID $env:COMMIT_ID -ReviewID $env:REVIEW_ID -ParametersFile $paramsFile | Tee-Object -FilePath $consoleLogFile
+& "$windowsBuildScript" -Branch $env:BRANCH -CommitID $env:COMMIT_ID -ReviewID $env:REVIEW_ID -ParametersFile $paramsFile -EnableSSL | Tee-Object -FilePath $consoleLogFile
 $exitCode = $LASTEXITCODE
 Remove-Item -Force -ErrorAction SilentlyContinue -Path $consoleLogFile
 exit $exitCode

--- a/Mesos/jenkins-jobs/mesos-nightly-build.ps1
+++ b/Mesos/jenkins-jobs/mesos-nightly-build.ps1
@@ -1,0 +1,9 @@
+$ErrorActionPreference = 'Stop'
+
+$paramsFile = Join-Path $env:WORKSPACE "mesos-build-parameters.txt"
+$consoleLogFile = Join-Path $env:WORKSPACE "mesos-build-${env:BRANCH}-${env:BUILD_NUMBER}.log"
+$windowsBuildScript = (Resolve-Path "$PSScriptRoot\..\start-windows-build.ps1").Path
+& "$windowsBuildScript" -Branch $env:BRANCH -CommitID $env:COMMIT_ID -ParametersFile $paramsFile | Tee-Object -FilePath $consoleLogFile
+$exitCode = $LASTEXITCODE
+Remove-Item -Force -ErrorAction SilentlyContinue -Path $consoleLogFile
+exit $exitCode

--- a/Mesos/start-windows-build.ps1
+++ b/Mesos/start-windows-build.ps1
@@ -6,7 +6,9 @@ Param(
     [Parameter(Mandatory=$false)]
     [string]$CommitID,
     [Parameter(Mandatory=$false)]
-    [string]$ParametersFile="${env:WORKSPACE}\build-parameters.txt"
+    [string]$ParametersFile="${env:WORKSPACE}\build-parameters.txt",
+    [Parameter(Mandatory=$false)]
+    [switch]$EnableSSL
 )
 
 $ErrorActionPreference = "Stop"
@@ -243,9 +245,12 @@ function Start-MesosBuild {
         } else {
             $generatorName = "Visual Studio 14 2015 Win64"
         }
+        $parameters = @("$MESOS_GIT_REPO_DIR", "-G", "`"$generatorName`"", "-T", "host=x64", "-DENABLE_LIBEVENT=ON", "-DHAS_AUTHENTICATION=ON", "-DENABLE_JAVA=ON")
+        if($EnableSSL) {
+            $parameters += "-DENABLE_SSL=ON"
+        }
         Start-MesosCIProcess -ProcessPath "cmake.exe" -StdoutFileName "mesos-build-cmake-stdout.log" -StderrFileName "mesos-build-cmake-stderr.log" `
-                             -ArgumentList @("$MESOS_GIT_REPO_DIR", "-G", "`"$generatorName`"", "-T", "host=x64", "-DENABLE_LIBEVENT=ON", "-DHAS_AUTHENTICATION=ON", "-DENABLE_JAVA=ON", "-DENABLE_SSL=ON") `
-                             -BuildErrorMessage "Mesos failed to build."
+                             -ArgumentList $parameters -BuildErrorMessage "Mesos failed to build."
     } finally {
         Copy-CmakeBuildLogs -BuildName 'mesos-build'
         Pop-Location


### PR DESCRIPTION
This pull request includes:

- Add workaround to enable RS3
- Temporarily, SSL is enabled only for the Reviewbot patches
- Add environment variables for the WinSW XML template
- Add parameter to enabled SSL when building Mesos
- Add Mesos nightly build Jenkins job script