### PR TITLE
Add ping to the Spartan addresses

### DIFF
--- a/DCOS/spartan-agent-setup.ps1
+++ b/DCOS/spartan-agent-setup.ps1
@@ -79,6 +79,10 @@ function Set-SpartanDevice {
     }
     Disable-NetAdapter $SPARTAN_DEVICE_NAME -Confirm:$false
     Enable-NetAdapter $SPARTAN_DEVICE_NAME -Confirm:$false
+    $spartanIPs = @("192.51.100.1", "192.51.100.2", "192.51.100.3")
+    foreach($ip in $spartanIPs) {
+        ping.exe -n 10 $ip
+    }
 }
 
 function Get-UpstreamDNSResolvers {


### PR DESCRIPTION
Due to the fact that Spartan addresses are not available right away,
we do a ping to each address to make sure that they are responsive.