### PR TITLE
Fix typo for Mesos stdout-tests and add log timestamp

### DIFF
--- a/Mesos/README.md
+++ b/Mesos/README.md
@@ -7,7 +7,7 @@ The process of testing the Mesos builds is done with the `start-windows-build.ps
 * Install all the prerequisites necessary for the Windows Mesos build;
 * Create a new tests environment. At this step, the build directories are created and the Mesos git repository is cloned. If the `start-windows-build.ps1` receives the `$CommitID` parameter, then the Mesos latest commit is set to that one. In addition to that, if `$ReviewID` parameter is passed as well, the pending review request is applied locally, together with all the dependent review requests;
 * Build Mesos;
-* Build and run the Mesos `stdout-tests` unit tests;
+* Build and run the Mesos `stout-tests` unit tests;
 * Build and run the Mesos `libprocess-tests` unit tests;
 * Build and run the Mesos `mesos-tests` unit tests;
 * If no error has occurred until this step, then the Mesos binaries are generated and we successfully finish testing the current Mesos build.

--- a/Mesos/cron-jobs/trigger-nightly-build.sh
+++ b/Mesos/cron-jobs/trigger-nightly-build.sh
@@ -31,7 +31,7 @@ start_workers() {
         rm -rf $JENKINS_EXECUTOR_TEMP_DIR
         exit 1
     fi
-    echo "Starting $JENKINS_JOB_NAME"
+    echo "$(date +%m-%d-%y-%T) - Starting $JENKINS_JOB_NAME"
     echo "Jenkins servers used: ${JENKINS_AVAILABLE_SERVERS[*]}"
     start_worker
     wait_running_workers

--- a/Mesos/start-windows-build.ps1
+++ b/Mesos/start-windows-build.ps1
@@ -266,26 +266,26 @@ function Start-MesosBuild {
     }
 }
 
-function Start-StdoutTestsBuild {
-    Write-Output "Started Mesos stdout-tests build"
+function Start-StoutTestsBuild {
+    Write-Output "Started Mesos stout-tests build"
     Push-Location $MESOS_DIR
     try {
         Start-MesosCIProcess -ProcessPath "cmake.exe" -StdoutFileName "stout-tests-build-cmake-stdout.log" -StderrFileName "stout-tests-build-cmake-stderr.log" `
                              -ArgumentList @("--build", ".", "--target", "stout-tests", "--config", "Debug") `
-                             -BuildErrorMessage "Mesos stdout-tests failed to build."
+                             -BuildErrorMessage "Mesos stout-tests failed to build."
     } finally {
-        Copy-CmakeBuildLogs -BuildName 'stdout-tests'
+        Copy-CmakeBuildLogs -BuildName 'stout-tests'
         Pop-Location
     }
-    Write-Output "stdout-tests were successfully built"
+    Write-Output "stout-tests were successfully built"
 }
 
 function Start-StdoutTestsRun {
-    Write-Output "Started Mesos stdout-tests run"
+    Write-Output "Started Mesos stout-tests run"
     Start-MesosCIProcess -ProcessPath "$MESOS_DIR\3rdparty\stout\tests\Debug\stout-tests.exe" `
-                         -StdoutFileName "stdout-tests-stdout.log" -StderrFileName "stdout-tests-stderr.log" `
-                         -BuildErrorMessage "Some Mesos stdout-tests tests failed."
-    Write-Output "stdout-tests PASSED"
+                         -StdoutFileName "stout-tests-stdout.log" -StderrFileName "stout-tests-stderr.log" `
+                         -BuildErrorMessage "Some Mesos stout-tests tests failed."
+    Write-Output "stout-tests PASSED"
 }
 
 function Start-LibprocessTestsBuild {
@@ -440,7 +440,7 @@ function Start-LogServerFilesUpload {
 function Start-EnvironmentCleanup {
     # Stop any potential hanging process
     $processes = @('python', 'git', 'cl', 'cmake',
-                   'stdout-tests', 'libprocess-tests', 'mesos-tests')
+                   'stout-tests', 'libprocess-tests', 'mesos-tests')
     $processes | Foreach-Object { Stop-Process -Name $_ -Force -ErrorAction SilentlyContinue }
     cmd.exe /C "rmdir /s /q $MESOS_DIR > nul 2>&1"
 }
@@ -462,7 +462,7 @@ try {
     Install-Prerequisites
     New-Environment
     Start-MesosBuild
-    Start-StdoutTestsBuild
+    Start-StoutTestsBuild
     Start-StdoutTestsRun
     Start-LibprocessTestsBuild
     Start-LibprocessTestsRun


### PR DESCRIPTION
This pull request introduces the following updates:

- Add a timestamp log for the trigger-nightly-build.sh cron job
- Fix typo for the Mesos `stout-tests`. The `stout-tests` were incorrectly logged as `stdout-tests`