### PR TITLE
Fix error when starting dcos-testing job

### DIFF
--- a/DCOS/jenkins-jobs/dcos-testing.sh
+++ b/DCOS/jenkins-jobs/dcos-testing.sh
@@ -64,7 +64,7 @@ BUILD_OUTPUTS_URL="$LOGS_BASE_URL/$BUILD_ID"
 PARAMETERS_FILE="$WORKSPACE/build-parameters.txt"
 TEMP_LOGS_DIR="/tmp/dcos-logs/$BUILD_ID"
 rm -f $PARAMETERS_FILE && touch $PARAMETERS_FILE
-rm -rf $TEMP_LOGS_DIR && mkdir $TEMP_LOGS_DIR
+rm -rf $TEMP_LOGS_DIR && mkdir -p $TEMP_LOGS_DIR
 rm -rf $HOME/.dcos
 
 . $UTILS_FILE


### PR DESCRIPTION
When trying to create the `$TEMP_LOGS_DIR`, the command fails
if the parent directory doesn't exit.

To fix this issue we added the `-p` parameter to the mkdir,
so that the parent directory gets created as well.
  