### PR TITLE
Parallel cmake builds & other updates

### DIFF
--- a/DCOS/jenkins-jobs/dcos-testing.sh
+++ b/DCOS/jenkins-jobs/dcos-testing.sh
@@ -59,6 +59,7 @@ LOG_SERVER_ADDRESS="10.3.1.6"
 LOG_SERVER_USER="logs"
 REMOTE_LOGS_DIR="/data/dcos-testing"
 LOGS_BASE_URL="http://dcos-win.westus.cloudapp.azure.com/dcos-testing"
+JENKINS_SERVER_URL="https://mesos-jenkins.westus.cloudapp.azure.com:8443"
 UTILS_FILE="$DIR/../utils/utils.sh"
 BUILD_OUTPUTS_URL="$LOGS_BASE_URL/$BUILD_ID"
 PARAMETERS_FILE="$WORKSPACE/build-parameters.txt"
@@ -85,7 +86,7 @@ upload_logs() {
     # Uploads the logs to the log server
     #
     # Copy the Jenkins console as well
-    cp $JENKINS_HOME/jobs/dcos-testing/builds/$BUILD_NUMBER/log $TEMP_LOGS_DIR/jenkins-console.log || return 1
+    wget --no-check-certificate "${JENKINS_SERVER_URL}/job/${JOB_NAME}/${BUILD_NUMBER}/consoleText" -O $TEMP_LOGS_DIR/jenkins-console.log || return 1
     echo "Uploading logs to the log server"
     upload_files_via_scp $LOG_SERVER_USER $LOG_SERVER_ADDRESS "22" "${REMOTE_LOGS_DIR}/" $TEMP_LOGS_DIR || return 1
     echo "All the logs available at: $BUILD_OUTPUTS_URL"

--- a/Mesos/start-windows-build.ps1
+++ b/Mesos/start-windows-build.ps1
@@ -259,7 +259,7 @@ function Start-MesosBuild {
     Push-Location $MESOS_DIR
     try {
         Start-MesosCIProcess -ProcessPath "cmake.exe" -StdoutFileName "mesos-java-build-cmake-stdout.log" -StderrFileName "mesos-java-build-cmake-stderr.log" `
-                             -ArgumentList @("--build", ".", "--target", "mesos-java") -BuildErrorMessage "mesos-java failed to build."
+                             -ArgumentList @("--build", ".", "--target", "mesos-java", "-- /maxcpucount") -BuildErrorMessage "mesos-java failed to build."
     } finally {
         Copy-CmakeBuildLogs -BuildName 'mesos-java-build'
         Pop-Location
@@ -271,7 +271,7 @@ function Start-StoutTestsBuild {
     Push-Location $MESOS_DIR
     try {
         Start-MesosCIProcess -ProcessPath "cmake.exe" -StdoutFileName "stout-tests-build-cmake-stdout.log" -StderrFileName "stout-tests-build-cmake-stderr.log" `
-                             -ArgumentList @("--build", ".", "--target", "stout-tests", "--config", "Debug") `
+                             -ArgumentList @("--build", ".", "--target", "stout-tests", "--config", "Debug", "-- /maxcpucount") `
                              -BuildErrorMessage "Mesos stout-tests failed to build."
     } finally {
         Copy-CmakeBuildLogs -BuildName 'stout-tests'
@@ -293,7 +293,7 @@ function Start-LibprocessTestsBuild {
     Push-Location $MESOS_DIR
     try {
         Start-MesosCIProcess -ProcessPath "cmake.exe" -StdoutFileName "libprocess-tests-build-cmake-stdout.log" -StderrFileName "libprocess-tests-build-cmake-stderr.log" `
-                             -ArgumentList @("--build", ".", "--target", "libprocess-tests", "--config", "Debug") `
+                             -ArgumentList @("--build", ".", "--target", "libprocess-tests", "--config", "Debug", "-- /maxcpucount") `
                              -BuildErrorMessage "Mesos libprocess-tests failed to build"
     } finally {
         Copy-CmakeBuildLogs -BuildName 'libprocess-tests'
@@ -315,7 +315,7 @@ function Start-MesosTestsBuild {
     Push-Location $MESOS_DIR
     try {
         Start-MesosCIProcess -ProcessPath "cmake.exe" -StdoutFileName "mesos-tests-build-cmake-stdout.log" -StderrFileName "mesos-tests-build-cmake-stderr.log" `
-                             -ArgumentList @("--build", ".", "--target", "mesos-tests", "--config", "Debug") `
+                             -ArgumentList @("--build", ".", "--target", "mesos-tests", "--config", "Debug", "-- /maxcpucount") `
                              -BuildErrorMessage "Mesos tests failed to build."
     } finally {
         Copy-CmakeBuildLogs -BuildName 'mesos-tests'
@@ -337,7 +337,7 @@ function New-MesosBinaries {
     Push-Location $MESOS_DIR
     try {
         Start-MesosCIProcess -ProcessPath "cmake.exe" -StdoutFileName "mesos-binaries-build-cmake-stdout.log" -StderrFileName "mesos-binaries-build-cmake-stderr.log" `
-                             -ArgumentList @("--build", ".") -BuildErrorMessage "Mesos binaries failed to build."
+                             -ArgumentList @("--build", ".", "-- /maxcpucount") -BuildErrorMessage "Mesos binaries failed to build."
     } finally {
         Copy-CmakeBuildLogs -BuildName 'mesos-binaries'
         Pop-Location

--- a/Mesos/utils/common.py
+++ b/Mesos/utils/common.py
@@ -68,6 +68,10 @@ class ReviewBoardHandler(object):
             review_url = review["href"]
             print "Dependent review: %s " % review_url
             dependent_review = self.api(review_url)["review_request"]
+            if dependent_review["id"] == review_request["id"]:
+                raise ReviewError("Circular dependency detected for "
+                                  "review %s. Please fix the "
+                                  "'depends_on' field." % review_request["id"])
             review_ids += self.get_review_ids(dependent_review)
         if review_request["id"] in review_ids:
             raise ReviewError("Circular dependency detected for "


### PR DESCRIPTION
This pull request includes the following updates:

- Add missing check for circular dependencies for the `verify-review-requests.py` python script
- Enable parallel cmake builds
- Update Jenkins console log file copy