### PR TITLE
Expanded E2E test to also test mesos authentication.

### DIFF
--- a/DCOS/templates/acs-engine-hybrid.json
+++ b/DCOS/templates/acs-engine-hybrid.json
@@ -11,13 +11,21 @@
     "masterProfile": {
       "count": 3,
       "dnsPrefix": "${LINUX_MASTER_DNS_PREFIX}",
-      "vmSize": "${LINUX_MASTER_SIZE}"
+      "vmSize": "${LINUX_MASTER_SIZE}",
+      "preProvisionExtension": {
+        "name": "preprovision-master-linux",
+        "singleOrAll": "All"
+      }
     },
     "agentPoolProfiles": [
       {
         "name": "${WIN_AGENT_PUBLIC_POOL}",
         "count": 1,
         "vmSize": "${WIN_AGENT_SIZE}",
+        "preProvisionExtension": {
+            "name": "preprovision-agent-windows",
+            "singleOrAll": "All"
+        },
         "osType": "Windows",
         "customNodeLabels": {
           "infrastructure": "ci"
@@ -34,6 +42,10 @@
         "name": "${WIN_AGENT_PRIVATE_POOL}",
         "count": 1,
         "vmSize": "${WIN_AGENT_SIZE}",
+        "preProvisionExtension": {
+            "name": "preprovision-agent-windows",
+            "singleOrAll": "All"
+        },
         "osType": "Windows",
         "dnsPrefix": "",
         "customNodeLabels": {
@@ -44,6 +56,10 @@
         "name": "${LINUX_AGENT_PUBLIC_POOL}",
         "count": 1,
         "vmSize": "${LINUX_AGENT_SIZE}",
+        "preProvisionExtension": {
+            "name": "preprovision-agent-linux-public",
+            "singleOrAll": "All"
+        },
         "osType": "linux",
         "dnsPrefix": "${LINUX_AGENT_DNS_PREFIX}",
         "customNodeLabels": {
@@ -59,6 +75,10 @@
         "name": "${LINUX_AGENT_PRIVATE_POOL}",
         "count": 1,
         "vmSize": "${LINUX_AGENT_SIZE}",
+        "preProvisionExtension": {
+            "name": "preprovision-agent-linux-private",
+            "singleOrAll": "All"
+        },
         "osType": "linux",
         "dnsPrefix": "",
         "customNodeLabels": {
@@ -79,6 +99,36 @@
           }
         ]
       }
-    }
+    },
+    "extensionProfiles": [
+      {
+        "name": "preprovision-agent-linux-public",
+        "version": "v1",
+        "extensionParameters": "parameters",
+        "rootURL": "http://13.68.86.214/preprovision/",
+        "script": "preprovision-agent-linux-public.sh"
+      },
+      {
+        "name": "preprovision-agent-linux-private",
+        "version": "v1",
+        "extensionParameters": "parameters",
+        "rootURL": "http://13.68.86.214/preprovision/",
+        "script": "preprovision-agent-linux-private.sh"
+      },
+      {
+        "name": "preprovision-master-linux",
+        "version": "v1",
+        "extensionParameters": "parameters",
+        "rootURL": "http://13.68.86.214/preprovision/",
+        "script": "preprovision-master-linux.sh"
+      },
+      {
+        "name": "preprovision-agent-windows",
+        "version": "v1",
+        "extensionParameters": "parameters",
+        "rootURL": "http://13.68.86.214/preprovision/",
+        "script": "preprovision-agent-windows.ps1"
+      }
+    ]
   }
 }

--- a/DCOS/templates/preprovision/extensions/preprovision-agent-linux-private/v1/preprovision-agent-linux-private.sh
+++ b/DCOS/templates/preprovision/extensions/preprovision-agent-linux-private/v1/preprovision-agent-linux-private.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+mkdir -p /etc/ethos/
+touch /etc/ethos/dcos-mesos-agent-secret
+chmod 600 /etc/ethos/dcos-mesos-agent-secret
+cat > /etc/ethos/dcos-mesos-agent-secret << EOF
+{
+  "principal": "mycred1",
+  "secret": "mysecret1"
+}
+EOF
+
+touch /etc/ethos/dcos-mesos-agent-http-credentials
+chmod 600 /etc/ethos/dcos-mesos-agent-http-credentials
+cat > /etc/ethos/dcos-mesos-agent-http-credentials << EOF
+{
+  "credentials": [
+    {
+      "principal": "mycred2",
+      "secret": "mysecret2"
+    }
+  ]
+}
+EOF
+
+mkdir -p /etc/systemd/system/dcos-mesos-slave.service.d
+echo "[Service]
+Environment=MESOS_AUTHENTICATE_HTTP_READONLY=true
+Environment=MESOS_AUTHENTICATE_HTTP_READWRITE=true
+Environment=MESOS_HTTP_CREDENTIALS=/etc/ethos/dcos-mesos-agent-http-credentials
+Environment=MESOS_CREDENTIAL=/etc/ethos/dcos-mesos-agent-secret" > /etc/systemd/system/dcos-mesos-slave.service.d/10-dcos-mesos-agent-auth.conf

--- a/DCOS/templates/preprovision/extensions/preprovision-agent-linux-public/v1/preprovision-agent-linux-public.sh
+++ b/DCOS/templates/preprovision/extensions/preprovision-agent-linux-public/v1/preprovision-agent-linux-public.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+mkdir -p /etc/ethos/
+touch /etc/ethos/dcos-mesos-agent-secret
+chmod 600 /etc/ethos/dcos-mesos-agent-secret
+cat > /etc/ethos/dcos-mesos-agent-secret << EOF
+{
+  "principal": "mycred1",
+  "secret": "mysecret1"
+}
+EOF
+
+touch /etc/ethos/dcos-mesos-agent-http-credentials
+chmod 600 /etc/ethos/dcos-mesos-agent-http-credentials
+cat > /etc/ethos/dcos-mesos-agent-http-credentials << EOF
+{
+  "credentials": [
+    {
+      "principal": "mycred2",
+      "secret": "mysecret2"
+    }
+  ]
+}
+EOF
+
+mkdir -p /etc/systemd/system/dcos-mesos-slave-public.service.d
+echo "[Service]
+Environment=MESOS_AUTHENTICATE_HTTP_READONLY=true
+Environment=MESOS_AUTHENTICATE_HTTP_READWRITE=true
+Environment=MESOS_HTTP_CREDENTIALS=/etc/ethos/dcos-mesos-agent-http-credentials
+Environment=MESOS_CREDENTIAL=/etc/ethos/dcos-mesos-agent-secret" > /etc/systemd/system/dcos-mesos-slave-public.service.d/10-dcos-mesos-agent-public-auth.conf
+

--- a/DCOS/templates/preprovision/extensions/preprovision-agent-windows/v1/preprovision-agent-windows.ps1
+++ b/DCOS/templates/preprovision/extensions/preprovision-agent-windows/v1/preprovision-agent-windows.ps1
@@ -1,12 +1,13 @@
-New-Item -ItemType Directory -Force -Path C:/DCOS/mesos/service/
+$MESOS_SERVICE_DIR = Join-Path $env:SystemDrive "DCOS\mesos\service"
+New-Item -ItemType Directory -Force -Path $MESOS_SERVICE_DIR
 
 $UTF8NoBOM = New-Object System.Text.UTF8Encoding $False
 
 $cred = "{`"principal`": `"mycred1`", `"secret`": `"mysecret1`"}"
-[System.IO.File]::WriteAllLines("C:\DCOS\mesos\service\credential.json", $cred, $UTF8NoBOM)
+[System.IO.File]::WriteAllLines("$MESOS_SERVICE_DIR\credential.json", $cred, $UTF8NoBOM)
 
 $httpCred = "{`"credentials`": [{`"principal`": `"mycred2`", `"secret`": `"mysecret2`"}]}"
-[System.IO.File]::WriteAllLines("C:\DCOS\mesos\service\http_credential.json", $httpCred, $UTF8NoBOM)
+[System.IO.File]::WriteAllLines("$MESOS_SERVICE_DIR\http_credential.json", $httpCred, $UTF8NoBOM)
 
-$serviceEnv = "MESOS_AUTHENTICATE_HTTP_READONLY=true`r`nMESOS_AUTHENTICATE_HTTP_READWRITE=true`r`nMESOS_HTTP_CREDENTIALS=C:\DCOS\mesos\service\http_credential.json`r`nMESOS_CREDENTIAL=C:\DCOS\mesos\service\credential.json"
-[System.IO.File]::WriteAllLines("C:\DCOS\mesos\service\environment-file", $serviceEnv, $UTF8NoBOM)
+$serviceEnv = "MESOS_AUTHENTICATE_HTTP_READONLY=true`r`nMESOS_AUTHENTICATE_HTTP_READWRITE=true`r`nMESOS_HTTP_CREDENTIALS=$MESOS_SERVICE_DIR\http_credential.json`r`nMESOS_CREDENTIAL=$MESOS_SERVICE_DIR\credential.json"
+[System.IO.File]::WriteAllLines("$MESOS_SERVICE_DIR\environment-file", $serviceEnv, $UTF8NoBOM)

--- a/DCOS/templates/preprovision/extensions/preprovision-agent-windows/v1/preprovision-agent-windows.ps1
+++ b/DCOS/templates/preprovision/extensions/preprovision-agent-windows/v1/preprovision-agent-windows.ps1
@@ -1,0 +1,12 @@
+New-Item -ItemType Directory -Force -Path C:/DCOS/mesos/service/
+
+$UTF8NoBOM = New-Object System.Text.UTF8Encoding $False
+
+$cred = "{`"principal`": `"mycred1`", `"secret`": `"mysecret1`"}"
+[System.IO.File]::WriteAllLines("C:\DCOS\mesos\service\credential.json", $cred, $UTF8NoBOM)
+
+$httpCred = "{`"credentials`": [{`"principal`": `"mycred2`", `"secret`": `"mysecret2`"}]}"
+[System.IO.File]::WriteAllLines("C:\DCOS\mesos\service\http_credential.json", $httpCred, $UTF8NoBOM)
+
+$serviceEnv = "MESOS_AUTHENTICATE_HTTP_READONLY=true`r`nMESOS_AUTHENTICATE_HTTP_READWRITE=true`r`nMESOS_HTTP_CREDENTIALS=C:\DCOS\mesos\service\http_credential.json`r`nMESOS_CREDENTIAL=C:\DCOS\mesos\service\credential.json"
+[System.IO.File]::WriteAllLines("C:\DCOS\mesos\service\environment-file", $serviceEnv, $UTF8NoBOM)

--- a/DCOS/templates/preprovision/extensions/preprovision-master-linux/v1/preprovision-master-linux.sh
+++ b/DCOS/templates/preprovision/extensions/preprovision-master-linux/v1/preprovision-master-linux.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+mkdir -p /etc/ethos/
+touch /etc/ethos/dcos-mesos-master-secrets
+chmod 600 /etc/ethos/dcos-mesos-master-secrets
+cat > /etc/ethos/dcos-mesos-master-secrets << EOF
+{
+  "credentials": [
+    {
+      "principal": "mycred1",
+      "secret": "mysecret1"
+    }
+  ]
+}
+EOF
+
+mkdir -p /etc/systemd/system/dcos-mesos-master.service.d
+echo "[Service]
+Environment=MESOS_CREDENTIALS=/etc/ethos/dcos-mesos-master-secrets
+Environment=MESOS_AUTHENTICATE_AGENTS=true" > /etc/systemd/system/dcos-mesos-master.service.d/10-dcos-mesos-authentication.conf
+


### PR DESCRIPTION
NOTE: Do not merge until some acs-engine changes go through. This expects acs-engine to have the ability to handle the preProvision extension.