### PR TITLE
E2E test to verify Spartan on Windows and other updates

### DIFF
--- a/DCOS/acs-engine-dcos-deploy.sh
+++ b/DCOS/acs-engine-dcos-deploy.sh
@@ -103,17 +103,14 @@ install_azure_cli_2
 
 # Generate the Azure ARM deploy files
 ACS_TEMPLATE="$TEMPLATES_DIR/acs-engine-${DCOS_DEPLOYMENT_TYPE}.json"
-ACS_RENDERED_TEMPLATE="/tmp/dcos-acs-engine.json"
-DCOS_DEPLOY_DIR="/tmp/dcos-windows-deploy-dir"
+DCOS_DEPLOY_DIR=$(mktemp -d -t "dcos-deploy-XXXXXXXXXX")
+ACS_RENDERED_TEMPLATE="${DCOS_DEPLOY_DIR}/acs-engine-template.json"
 eval "cat << EOF
 $(cat $ACS_TEMPLATE)
 EOF
 " > $ACS_RENDERED_TEMPLATE
-rm -rf $DCOS_DEPLOY_DIR
 acs-engine generate --output-directory $DCOS_DEPLOY_DIR $ACS_RENDERED_TEMPLATE
 rm -rf ./translations # Left-over after running 'acs-engine generate'
-rm $ACS_RENDERED_TEMPLATE
-
 
 # Deploy the DCOS with Mesos environment
 DEPLOY_TEMPLATE_FILE="$DCOS_DEPLOY_DIR/azuredeploy.json"

--- a/DCOS/dcos-testing.sh
+++ b/DCOS/dcos-testing.sh
@@ -108,10 +108,15 @@ check_open_port() {
     local PORT="$2"
     local TIMEOUT=300
     echo "Checking, with a timeout of $TIMEOUT seconds, if the port $PORT is open at the address: $ADDRESS"
-    nc -v -z "$ADDRESS" "$PORT" -w $TIMEOUT || {
-        echo "ERROR: Port $PORT is not open at the address: $ADDRESS"
-        return 1
-    }
+    SECONDS=0
+    while true; do
+        if [[ $SECONDS -gt $TIMEOUT ]]; then
+            echo "ERROR: Port $PORT didn't open at $ADDRESS within $TIMEOUT seconds"
+            return 1
+        fi
+        nc -v -z "$ADDRESS" "$PORT" &>/dev/null && break || sleep 1
+    done
+    echo "Success: Port $PORT is open at address $ADDRESS"
 }
 
 open_dcos_port() {

--- a/DCOS/dcos-testing.sh
+++ b/DCOS/dcos-testing.sh
@@ -67,11 +67,9 @@ LOGS_BASE_URL="http://dcos-win.westus.cloudapp.azure.com/dcos-testing"
 JENKINS_SERVER_URL="https://mesos-jenkins.westus.cloudapp.azure.com:8443"
 UTILS_FILE="$DIR/utils/utils.sh"
 BUILD_OUTPUTS_URL="$LOGS_BASE_URL/$BUILD_ID"
-WORK_DIR="/tmp/jenkins-${JOB_NAME}/${BUILD_ID}"
-PARAMETERS_FILE="$WORK_DIR/build-parameters.txt"
-TEMP_LOGS_DIR="$WORK_DIR/dcos-logs"
-rm -f $PARAMETERS_FILE && touch $PARAMETERS_FILE && \
-rm -rf $TEMP_LOGS_DIR && mkdir -p $TEMP_LOGS_DIR && \
+PARAMETERS_FILE="$WORKSPACE/build-parameters.txt"
+TEMP_LOGS_DIR="$WORKSPACE/$BUILD_ID"
+rm -f $PARAMETERS_FILE && touch $PARAMETERS_FILE && mkdir -p $TEMP_LOGS_DIR && \
 rm -rf $HOME/.dcos && source $UTILS_FILE || exit 1
 
 

--- a/DCOS/dcos-testing.sh
+++ b/DCOS/dcos-testing.sh
@@ -67,8 +67,9 @@ LOGS_BASE_URL="http://dcos-win.westus.cloudapp.azure.com/dcos-testing"
 JENKINS_SERVER_URL="https://mesos-jenkins.westus.cloudapp.azure.com:8443"
 UTILS_FILE="$DIR/utils/utils.sh"
 BUILD_OUTPUTS_URL="$LOGS_BASE_URL/$BUILD_ID"
-PARAMETERS_FILE="$WORKSPACE/build-parameters.txt"
-TEMP_LOGS_DIR="/tmp/dcos-logs/$BUILD_ID"
+WORK_DIR="/tmp/jenkins-${JOB_NAME}/${BUILD_ID}"
+PARAMETERS_FILE="$WORK_DIR/build-parameters.txt"
+TEMP_LOGS_DIR="$WORK_DIR/dcos-logs"
 rm -f $PARAMETERS_FILE && touch $PARAMETERS_FILE && \
 rm -rf $TEMP_LOGS_DIR && mkdir -p $TEMP_LOGS_DIR && \
 rm -rf $HOME/.dcos && source $UTILS_FILE || exit 1

--- a/DCOS/dcos-testing.sh
+++ b/DCOS/dcos-testing.sh
@@ -121,7 +121,7 @@ open_dcos_port() {
     #
     # This function opens the GUI endpoint on the first master unit
     #
-    echo "Opening DCOS port: 80" 
+    echo "Open DCOS port 80"
     MASTER_LB_NAME=$(az network lb list --resource-group $AZURE_RESOURCE_GROUP --output table | grep 'dcos-master' | awk '{print $2}') || {
         echo "ERROR: Failed to get the master load balancer name"
         return 1
@@ -132,6 +132,7 @@ open_dcos_port() {
         return 1
     }
     NAT_RULE_NAME="DCOS_Port_80"
+    echo "Create inbound NAT rule for DCOS port 80"
     az network lb inbound-nat-rule create --resource-group $AZURE_RESOURCE_GROUP --lb-name $MASTER_LB_NAME \
                                           --name $NAT_RULE_NAME --protocol Tcp --frontend-port 80 --backend-port 80 --output table || {
         echo "ERROR: Failed to create load balancer inbound NAT rule"
@@ -142,6 +143,7 @@ open_dcos_port() {
         echo "ERROR: Failed to create ip-config inbound-nat-rule"
         return 1
     }
+    echo "Add security group rule for DCOS port 80"
     MASTER_SG_NAME=$(az network nsg list --resource-group $AZURE_RESOURCE_GROUP --output table | grep 'dcos-master' | awk '{print $2}') || {
         echo "ERROR: Failed to get the master security name"
         return 1

--- a/DCOS/dcos-testing.sh
+++ b/DCOS/dcos-testing.sh
@@ -422,8 +422,15 @@ install_dcos_cli() {
     fi
     DCOS_BINARY_FILE="/usr/local/bin/dcos"
     sudo curl $DCOS_CLI_URL -o $DCOS_BINARY_FILE && \
-    sudo chmod +x $DCOS_BINARY_FILE && \
-    dcos cluster setup "http://${MASTER_PUBLIC_ADDRESS}:80" || return 1
+    sudo chmod +x $DCOS_BINARY_FILE || {
+        echo "ERROR: Failed to install the DCOS CLI"
+        return 1
+    }
+    if [[ "$DCOS_VERSION" = "1.8.8" ]] || [[ "$DCOS_VERSION" = "1.9.0" ]]; then
+        dcos config set core.dcos_url "http://${MASTER_PUBLIC_ADDRESS}:80" || return 1
+    else
+        dcos cluster setup "http://${MASTER_PUBLIC_ADDRESS}:80" || return 1
+    fi
 }
 
 check_exit_code() {

--- a/DCOS/dcos-testing.sh
+++ b/DCOS/dcos-testing.sh
@@ -141,7 +141,7 @@ open_dcos_port() {
     }
     az network nic ip-config inbound-nat-rule add --resource-group $AZURE_RESOURCE_GROUP --lb-name $MASTER_LB_NAME --nic-name $MASTER_NIC_NAME \
                                                   --inbound-nat-rule $NAT_RULE_NAME --ip-config-name ipConfigNode --output table || {
-        echo "ERROR: Failed to ip-config inbound-nat-rule"
+        echo "ERROR: Failed to create ip-config inbound-nat-rule"
         return 1
     }
     MASTER_SG_NAME=$(az network nsg list --resource-group $AZURE_RESOURCE_GROUP --output table | grep 'dcos-master' | awk '{print $2}') || {

--- a/DCOS/templates/acs-engine-hybrid.json
+++ b/DCOS/templates/acs-engine-hybrid.json
@@ -106,28 +106,28 @@
         "name": "preprovision-agent-linux-public",
         "version": "v1",
         "extensionParameters": "parameters",
-        "rootURL": "http://13.68.86.214/preprovision/",
+        "rootURL": "http://dcos-win.westus.cloudapp.azure.com/dcos-windows-ci/preprovision/",
         "script": "preprovision-agent-linux-public.sh"
       },
       {
         "name": "preprovision-agent-linux-private",
         "version": "v1",
         "extensionParameters": "parameters",
-        "rootURL": "http://13.68.86.214/preprovision/",
+        "rootURL": "http://dcos-win.westus.cloudapp.azure.com/dcos-windows-ci/preprovision/",
         "script": "preprovision-agent-linux-private.sh"
       },
       {
         "name": "preprovision-master-linux",
         "version": "v1",
         "extensionParameters": "parameters",
-        "rootURL": "http://13.68.86.214/preprovision/",
+        "rootURL": "http://dcos-win.westus.cloudapp.azure.com/dcos-windows-ci/preprovision/",
         "script": "preprovision-master-linux.sh"
       },
       {
         "name": "preprovision-agent-windows",
         "version": "v1",
         "extensionParameters": "parameters",
-        "rootURL": "http://13.68.86.214/preprovision/",
+        "rootURL": "http://dcos-win.westus.cloudapp.azure.com/dcos-windows-ci/preprovision/",
         "script": "preprovision-agent-windows.ps1"
       }
     ]

--- a/DCOS/templates/marathon-fetcher-http.json
+++ b/DCOS/templates/marathon-fetcher-http.json
@@ -12,12 +12,11 @@
       "Windows"
     ]
   ],
+  "networks": [ { "mode": "container", "name": "customnat" } ],
   "container": {
     "type": "DOCKER",
-    "networks": [ { "mode": "container", "name": "nat_network" } ],
     "docker": {
       "image": "microsoft/iis:windowsservercore-1709",
-      "network": "BRIDGE",
       "parameters": [
         {
           "key": "publish",

--- a/DCOS/templates/marathon-fetcher-http.json
+++ b/DCOS/templates/marathon-fetcher-http.json
@@ -12,11 +12,11 @@
       "Windows"
     ]
   ],
-  "networks": [ { "mode": "container", "name": "customnat" } ],
   "container": {
     "type": "DOCKER",
     "docker": {
       "image": "microsoft/iis:windowsservercore-1709",
+      "network": "BRIDGE",
       "parameters": [
         {
           "key": "publish",

--- a/DCOS/templates/marathon-fetcher-https.json
+++ b/DCOS/templates/marathon-fetcher-https.json
@@ -12,12 +12,11 @@
       "Windows"
     ]
   ],
+  "networks": [ { "mode": "container", "name": "customnat" } ],
   "container": {
     "type": "DOCKER",
-    "networks": [ { "mode": "container", "name": "nat_network" } ],
     "docker": {
       "image": "microsoft/iis:windowsservercore-1709",
-      "network": "BRIDGE",
       "parameters": [
         {
           "key": "publish",

--- a/DCOS/templates/marathon-fetcher-https.json
+++ b/DCOS/templates/marathon-fetcher-https.json
@@ -12,11 +12,11 @@
       "Windows"
     ]
   ],
-  "networks": [ { "mode": "container", "name": "customnat" } ],
   "container": {
     "type": "DOCKER",
     "docker": {
       "image": "microsoft/iis:windowsservercore-1709",
+      "network": "BRIDGE",
       "parameters": [
         {
           "key": "publish",

--- a/DCOS/templates/marathon-fetcher-local.json
+++ b/DCOS/templates/marathon-fetcher-local.json
@@ -12,12 +12,11 @@
       "Windows"
     ]
   ],
+  "networks": [ { "mode": "container", "name": "customnat" } ],
   "container": {
     "type": "DOCKER",
-    "networks": [ { "mode": "container", "name": "nat_network" } ],
     "docker": {
       "image": "microsoft/iis:windowsservercore-1709",
-      "network": "BRIDGE",
       "parameters": [
         {
           "key": "publish",

--- a/DCOS/templates/marathon-fetcher-local.json
+++ b/DCOS/templates/marathon-fetcher-local.json
@@ -12,11 +12,11 @@
       "Windows"
     ]
   ],
-  "networks": [ { "mode": "container", "name": "customnat" } ],
   "container": {
     "type": "DOCKER",
     "docker": {
       "image": "microsoft/iis:windowsservercore-1709",
+      "network": "BRIDGE",
       "parameters": [
         {
           "key": "publish",

--- a/DCOS/templates/marathon-iis.json
+++ b/DCOS/templates/marathon-iis.json
@@ -12,13 +12,13 @@
       "Windows"
     ]
   ],
-  "networks": [ { "mode": "container", "name": "customnat" } ],
   "container": {
     "type": "DOCKER",
     "volumes": [],
     "docker": {
       "image": "microsoft/iis:windowsservercore-1709",
       "privileged": false,
+      "network": "BRIDGE",
       "parameters": [
         {
           "key": "publish",

--- a/DCOS/templates/marathon-iis.json
+++ b/DCOS/templates/marathon-iis.json
@@ -12,12 +12,11 @@
       "Windows"
     ]
   ],
+  "networks": [ { "mode": "container", "name": "customnat" } ],
   "container": {
     "type": "DOCKER",
     "volumes": [],
-    "networks": [ { "mode": "container", "name": "nat_network" } ],
     "docker": {
-      "network": "BRIDGE",
       "image": "microsoft/iis:windowsservercore-1709",
       "privileged": false,
       "parameters": [

--- a/Mesos/start-windows-build.ps1
+++ b/Mesos/start-windows-build.ps1
@@ -427,7 +427,14 @@ function Get-SuccessBuildMessage {
 function Start-TempDirCleanup {
     Get-ChildItem $env:TEMP | Where-Object {
         $_.Name -notmatch "^jna\-[0-9]*$|^hsperfdata.*_mesos$"
-    } | Remove-Item -Recurse -Force -ErrorAction SilentlyContinue
+    } | ForEach-Object {
+        $fullPath = $_.FullName
+        if($_.FullName -is [System.IO.DirectoryInfo]) {
+            cmd.exe /C "rmdir /s /q ${fullPath} > nul 2>&1"
+        } else {
+            cmd.exe /C "del /Q /S /F ${fullPath} > nul 2>&1"
+        }
+    }
 }
 
 function Start-MesosCITesting {

--- a/Spartan/start-windows-build.ps1
+++ b/Spartan/start-windows-build.ps1
@@ -1,5 +1,7 @@
 Param(
     [Parameter(Mandatory=$false)]
+    [string]$GitURL="http://github.com/dcos/spartan",
+    [Parameter(Mandatory=$false)]
     [string]$Branch="master",
     [Parameter(Mandatory=$false)]
     [string]$CommitID
@@ -101,7 +103,7 @@ function New-Environment {
     New-Directory $SPARTAN_DIR
     New-Directory $SPARTAN_BUILD_OUT_DIR
     New-Directory $SPARTAN_BUILD_LOGS_DIR
-    Start-GitClone -URL $SPARTAN_GIT_URL -Branch $Branch -Path $SPARTAN_GIT_REPO_DIR
+    Start-GitClone -URL $GitURL -Branch $Branch -Path $SPARTAN_GIT_REPO_DIR
     #
     # NOTE(ibalutoiu): Update the sys.config to use only a single process to
     #                  spawn for the Spartan handler. Otherwise, during the

--- a/Spartan/start-windows-build.ps1
+++ b/Spartan/start-windows-build.ps1
@@ -216,8 +216,8 @@ function Start-EnvironmentCleanup {
 
 try {
     New-Environment
-    Start-CommonTests
     Start-EUnitTests
+    Start-CommonTests
     Start-SpartanBuild
     $global:BUILD_STATUS = 'PASS'
 } catch {

--- a/global-variables.ps1
+++ b/global-variables.ps1
@@ -74,4 +74,3 @@ $7ZIP_DIR = Join-Path $env:ProgramFiles "7-Zip"
 
 # Git repositories URLs
 $MESOS_GIT_URL = "https://github.com/apache/mesos"
-$SPARTAN_GIT_URL = "https://github.com/dcos/spartan"


### PR DESCRIPTION
This pull request adds the following updates:

- Fix DC/OS config set for releases older than 1.10
- Update the script to check app tasks health
- Update preprovision scripts rootURL to the CI's stable URL
- Fix `check_open_port` logic
- Run Spartan eunit tests before common tests
- Fix temporary directory cleanup for the Mesos `start-windows-build.ps1` script
- Use first master as a proxy node to check fetcher functionality
- Add e-mail notifications for Spartan nightly build