### PR TITLE
Use az CLI to find slaves addresses and enable MESOS_HTTP health checks

### DIFF
--- a/DCOS/acs-engine-dcos-deploy.sh
+++ b/DCOS/acs-engine-dcos-deploy.sh
@@ -26,7 +26,7 @@ validate_simple_deployment_params() {
         exit 1
     fi
     if [[ -z $DCOS_WINDOWS_BOOTSTRAP_URL ]]; then
-        export DCOS_WINDOWS_BOOTSTRAP_URL="$CI_WEB_ROOT/dcos-windows/mesosphere"
+        export DCOS_WINDOWS_BOOTSTRAP_URL="$CI_WEB_ROOT/dcos-windows/testing"
     fi
     if [[ -z $DCOS_BOOTSTRAP_URL ]]; then
         export DCOS_BOOTSTRAP_URL="$CI_WEB_ROOT/dcos/bootstrap/latest.bootstrap.tar.xz"

--- a/DCOS/dcos-testing.sh
+++ b/DCOS/dcos-testing.sh
@@ -419,7 +419,6 @@ collect_dcos_nodes_logs() {
     # Collect logs from all the deployment nodes and upload them to the log server
     #
     echo "Collecting logs from all the DC/OS nodes"
-    dcos node --json > $TEMP_LOGS_DIR/dcos-nodes.json
 
     # Collect logs from all the Linux master node(s)
     echo "Collecting Linux master logs"
@@ -512,6 +511,7 @@ create_testing_environment() {
         echo "ERROR: Cannot find any cluster with the ID: $DCOS_CLUSTER_ID"
         return 1
     }
+    dcos node --json > $TEMP_LOGS_DIR/dcos-nodes.json
 }
 
 # Install latest stable ACS Engine tool

--- a/DCOS/dcos-testing.sh
+++ b/DCOS/dcos-testing.sh
@@ -42,6 +42,9 @@ else
     echo "ERROR: $DCOS_DEPLOYMENT_TYPE DCOS_DEPLOYMENT_TYPE is not supported"
     exit 1
 fi
+# LINUX_PRIVATE_IPS and WINDOWS_PRIVATE_IPS will be set later on in the script
+export LINUX_PRIVATE_IPS=""
+export WINDOWS_PRIVATE_IPS=""
 
 DIR=$(dirname $0)
 MASTER_PUBLIC_ADDRESS="${LINUX_MASTER_DNS_PREFIX}.${AZURE_REGION}.cloudapp.azure.com"
@@ -414,6 +417,48 @@ collect_windows_agents_logs() {
     done
 }
 
+linux_agents_private_ips() {
+    if [[ ! -z $LINUX_PRIVATE_IPS ]]; then
+        echo -e $LINUX_PRIVATE_IPS
+        return 0
+    fi
+    VMSS_NAMES=$(az vmss list --resource-group $AZURE_RESOURCE_GROUP | jq -r ".[] | select(.virtualMachineProfile.osProfile.linuxConfiguration != null) | .name") || {
+        echo "ERROR: Failed to get the Linux VMSS names"
+        return 1
+    }
+    PRIVATE_IPS=""
+    for VMSS_NAME in $VMSS_NAMES; do
+        IPS=$(az vmss nic list --resource-group $AZURE_RESOURCE_GROUP --vmss-name $VMSS_NAME | jq -r ".[] | .ipConfigurations[0].privateIpAddress") || {
+            echo "ERROR: Failed to get VMSS $VMSS_NAME private addresses"
+            return 1
+        }
+        PRIVATE_IPS="$IPS $PRIVATE_IPS"
+    done
+    export LINUX_PRIVATE_IPS="$PRIVATE_IPS"
+    echo -e $LINUX_PRIVATE_IPS
+}
+
+windows_agents_private_ips() {
+    if [[ ! -z $WINDOWS_PRIVATE_IPS ]]; then
+        echo -e $WINDOWS_PRIVATE_IPS
+        return 0
+    fi
+    VMSS_NAMES=$(az vmss list --resource-group $AZURE_RESOURCE_GROUP | jq -r ".[] | select(.virtualMachineProfile.osProfile.windowsConfiguration != null) | .name") || {
+        echo "ERROR: Failed to get the Windows VMSS names"
+        return 1
+    }
+    PRIVATE_IPS=""
+    for VMSS_NAME in $VMSS_NAMES; do
+        IPS=$(az vmss nic list --resource-group $AZURE_RESOURCE_GROUP --vmss-name $VMSS_NAME | jq -r ".[] | .ipConfigurations[0].privateIpAddress") || {
+            echo "ERROR: Failed to get VMSS $VMSS_NAME private addresses"
+            return 1
+        }
+        PRIVATE_IPS="$IPS $PRIVATE_IPS"
+    done
+    export WINDOWS_PRIVATE_IPS="$PRIVATE_IPS"
+    echo -e $WINDOWS_PRIVATE_IPS
+}
+
 collect_dcos_nodes_logs() {
     #
     # Collect logs from all the deployment nodes and upload them to the log server
@@ -431,38 +476,20 @@ collect_dcos_nodes_logs() {
     run_ssh_command $LINUX_ADMIN $MASTER_PUBLIC_ADDRESS "2200" 'mkdir -p $HOME/.ssh && chmod 700 $HOME/.ssh' || return 1
     upload_files_via_scp $LINUX_ADMIN $MASTER_PUBLIC_ADDRESS "2200" '$HOME/.ssh/id_rsa' "$HOME/.ssh/id_rsa" || return 1
 
-    # Collect logs from all the public Windows nodes(s)
-    echo "Collecting Windows public agents logs"
-    WIN_PUBLIC_LOGS_DIR="$TEMP_LOGS_DIR/windows_public_agents"
-    mkdir -p $WIN_PUBLIC_LOGS_DIR || return 1
-    IPS=$($DIR/utils/dcos-node-addresses.py --operating-system 'windows' --role 'public') || return 1
-    collect_windows_agents_logs "$WIN_PUBLIC_LOGS_DIR" "$IPS" || return 1
-
-    if [[ $WIN_PRIVATE_AGENT_COUNT -gt 0 ]]; then
-        echo "Collecting Windows private agents logs"
-        # Collect logs from all the private Windows nodes(s)
-        WIN_PRIVATE_LOGS_DIR="$TEMP_LOGS_DIR/windows_private_agents"
-        mkdir -p $WIN_PRIVATE_LOGS_DIR  || return 1
-        IPS=$($DIR/utils/dcos-node-addresses.py --operating-system 'windows' --role 'private') || return 1
-        collect_windows_agents_logs "$WIN_PRIVATE_LOGS_DIR" "$IPS" || return 1
+    IPS=$(linux_agents_private_ips)
+    if [[ ! -z $IPS ]]; then
+        echo "Collecting Linux agents logs"
+        LINUX_LOGS_DIR="$TEMP_LOGS_DIR/linux_agents"
+        mkdir -p $LINUX_LOGS_DIR || return 1
+        collect_linux_agents_logs "$LINUX_LOGS_DIR" "$IPS" || return 1
     fi
 
-    if [[ $LINUX_PUBLIC_AGENT_COUNT -gt 0 ]]; then
-        echo "Collecting Linux public agents logs"
-        # Collect logs from all the public Linux node(s)
-        LINUX_PUBLIC_LOGS_DIR="$TEMP_LOGS_DIR/linux_public_agents"
-        mkdir -p $LINUX_PUBLIC_LOGS_DIR || return 1
-        IPS=$($DIR/utils/dcos-node-addresses.py --operating-system 'linux' --role 'public') || return 1
-        collect_linux_agents_logs "$LINUX_PUBLIC_LOGS_DIR" "$IPS" || return 1
-    fi
-
-    if [[ $LINUX_PRIVATE_AGENT_COUNT -gt 0 ]]; then
-        echo "Collecting Linux private agents logs"
-        # Collect logs from all the private Linux node(s)
-        LINUX_PRIVATE_LOGS_DIR="$TEMP_LOGS_DIR/linux_private_agents"
-        mkdir -p $LINUX_PRIVATE_LOGS_DIR || return 1
-        IPS=$($DIR/utils/dcos-node-addresses.py --operating-system 'linux' --role 'private') || return 1
-        collect_linux_agents_logs "$LINUX_PRIVATE_LOGS_DIR" "$IPS" || return 1
+    IPS=$(windows_agents_private_ips)
+    if [[ ! -z $IPS ]]; then
+        echo "Collecting Windows agents logs"
+        WIN_LOGS_DIR="$TEMP_LOGS_DIR/windows_agents"
+        mkdir -p $WIN_LOGS_DIR || return 1
+        collect_windows_agents_logs "$WIN_LOGS_DIR" "$IPS" || return 1
     fi
 }
 
@@ -524,17 +551,17 @@ check_exit_code false
 
 # Deploy DC/OS master + slave nodes
 $DIR/acs-engine-dcos-deploy.sh
-check_exit_code false
+check_exit_code true
 echo "Linux master load balancer public address: $MASTER_PUBLIC_ADDRESS"
 echo "Windows agent load balancer public address: $WIN_AGENT_PUBLIC_ADDRESS"
 
 # Open DC/OS API & GUI port
 open_dcos_port
-check_exit_code false
+check_exit_code true
 
 # Create the testing environment
 create_testing_environment
-check_exit_code false
+check_exit_code true
 
 # Run the functional tests
 run_functional_tests

--- a/DCOS/dcos-testing.sh
+++ b/DCOS/dcos-testing.sh
@@ -387,7 +387,7 @@ collect_linux_agents_logs() {
     upload_files_via_scp $LINUX_ADMIN $MASTER_PUBLIC_ADDRESS "2200" "/tmp/utils.sh" "$DIR/utils/utils.sh" || return 1
     for IP in $AGENTS_IPS; do
         run_ssh_command $LINUX_ADMIN $MASTER_PUBLIC_ADDRESS "2200" "source /tmp/utils.sh && upload_files_via_scp $LINUX_ADMIN $IP 22 /tmp/collect-logs.sh /tmp/collect-logs.sh" || return 1
-        AGENT_LOGS_DIR="/tmp/agent_$IP"
+        AGENT_LOGS_DIR="/tmp/$IP"
         run_ssh_command $LINUX_ADMIN $MASTER_PUBLIC_ADDRESS "2200" "source /tmp/utils.sh && run_ssh_command $LINUX_ADMIN $IP 22 '/tmp/collect-logs.sh $AGENT_LOGS_DIR'" || return 1
         run_ssh_command $LINUX_ADMIN $MASTER_PUBLIC_ADDRESS "2200" "source /tmp/utils.sh && rm -rf $AGENT_LOGS_DIR && download_files_via_scp $IP 22 $AGENT_LOGS_DIR $AGENT_LOGS_DIR" || return 1
         download_files_via_scp $MASTER_PUBLIC_ADDRESS "2200" $AGENT_LOGS_DIR "${LOCAL_LOGS_DIR}/" || return 1
@@ -405,7 +405,7 @@ collect_windows_agents_logs() {
     local AGENTS_IPS="$2"
     upload_files_via_scp $LINUX_ADMIN $MASTER_PUBLIC_ADDRESS "2200" "/tmp/utils.sh" "$DIR/utils/utils.sh" || return 1
     for IP in $AGENTS_IPS; do
-        AGENT_LOGS_DIR="/tmp/agent_$IP"
+        AGENT_LOGS_DIR="/tmp/$IP"
         run_ssh_command $LINUX_ADMIN $MASTER_PUBLIC_ADDRESS "2200" "source /tmp/utils.sh && mount_smb_share $IP $WIN_AGENT_ADMIN $WIN_AGENT_ADMIN_PASSWORD && mkdir -p $AGENT_LOGS_DIR/logs && cp -rf /mnt/$IP/AzureData $AGENT_LOGS_DIR/" || return 1
         for SERVICE in "epmd" "mesos" "spartan"; do
             run_ssh_command $LINUX_ADMIN $MASTER_PUBLIC_ADDRESS "2200" "if [[ -e /mnt/$IP/DCOS/$SERVICE/log ]] ; then cp -rf /mnt/$IP/DCOS/$SERVICE/log $AGENT_LOGS_DIR/logs/$SERVICE ; fi" || return 1

--- a/DCOS/dcos-testing.sh
+++ b/DCOS/dcos-testing.sh
@@ -70,9 +70,11 @@ job_cleanup() {
     #
     # Deletes the Azure resource group used for the deployment
     #
-    dcos cluster remove $DCOS_CLUSTER_ID || {
-        echo "WARNING: Failed to remove the DC/OS cluster: $DCOS_CLUSTER_ID"
-    }
+    if [[ ! -z $DCOS_CLUSTER_ID ]]; then
+        dcos cluster remove $DCOS_CLUSTER_ID || {
+            echo "WARNING: Failed to remove the DC/OS cluster: $DCOS_CLUSTER_ID"
+        }
+    fi
     echo "Cleanup in progress for the current Azure DC/OS deployment"
     az group delete --yes --name $AZURE_RESOURCE_GROUP --output table || {
         echo "ERROR: Failed to delete the resource group"

--- a/DCOS/templates/marathon-fetcher-http.json
+++ b/DCOS/templates/marathon-fetcher-http.json
@@ -12,11 +12,11 @@
       "Windows"
     ]
   ],
+  "networks": [ { "mode": "container", "name": "customnat" } ],
   "container": {
     "type": "DOCKER",
     "docker": {
       "image": "microsoft/iis:windowsservercore-1709",
-      "network": "BRIDGE",
       "parameters": [
         {
           "key": "publish",
@@ -36,7 +36,7 @@
       "maxConsecutiveFailures": 3,
       "port": 80,
       "path": "/",
-      "protocol": "HTTP",
+      "protocol": "MESOS_HTTP",
       "ignoreHttp1xx": false
     }
   ],

--- a/DCOS/templates/marathon-fetcher-https.json
+++ b/DCOS/templates/marathon-fetcher-https.json
@@ -12,11 +12,11 @@
       "Windows"
     ]
   ],
+  "networks": [ { "mode": "container", "name": "customnat" } ],
   "container": {
     "type": "DOCKER",
     "docker": {
       "image": "microsoft/iis:windowsservercore-1709",
-      "network": "BRIDGE",
       "parameters": [
         {
           "key": "publish",
@@ -36,7 +36,7 @@
       "maxConsecutiveFailures": 3,
       "port": 80,
       "path": "/",
-      "protocol": "HTTP",
+      "protocol": "MESOS_HTTP",
       "ignoreHttp1xx": false
     }
   ],

--- a/DCOS/templates/marathon-fetcher-local.json
+++ b/DCOS/templates/marathon-fetcher-local.json
@@ -12,11 +12,11 @@
       "Windows"
     ]
   ],
+  "networks": [ { "mode": "container", "name": "customnat" } ],
   "container": {
     "type": "DOCKER",
     "docker": {
       "image": "microsoft/iis:windowsservercore-1709",
-      "network": "BRIDGE",
       "parameters": [
         {
           "key": "publish",
@@ -36,7 +36,7 @@
       "maxConsecutiveFailures": 3,
       "port": 80,
       "path": "/",
-      "protocol": "HTTP",
+      "protocol": "MESOS_HTTP",
       "ignoreHttp1xx": false
     }
   ],

--- a/DCOS/templates/marathon-iis.json
+++ b/DCOS/templates/marathon-iis.json
@@ -12,13 +12,13 @@
       "Windows"
     ]
   ],
+  "networks": [ { "mode": "container", "name": "customnat" } ],
   "container": {
     "type": "DOCKER",
     "volumes": [],
     "docker": {
       "image": "microsoft/iis:windowsservercore-1709",
       "privileged": false,
-      "network": "BRIDGE",
       "parameters": [
         {
           "key": "publish",
@@ -36,7 +36,7 @@
       "maxConsecutiveFailures": 3,
       "port": 80,
       "path": "/",
-      "protocol": "HTTP",
+      "protocol": "MESOS_HTTP",
       "ignoreHttp1xx": false
     }
   ],


### PR DESCRIPTION
This pull request includes the following updates:

- Use `customnat` Docker network and `MESOS_HTTP` health checks
- Change default `DCOS_WINDOWS_BOOTSTRAP_URL`
- Remove DC/OS client session only if `DCOS_CLUSTER_ID` is set
- Create `dcos-nodes.json` when initializing the testing env and not at the logs collection
- Remove `agent_` from the logs directory name