### PR TITLE
Various updates to the main `dcos-testing.sh` script

### DIFF
--- a/DCOS/dcos-testing.sh
+++ b/DCOS/dcos-testing.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 
-export BUILD_ID=$(date +%m%d%y%T | sed 's|\:||g')
 export AZURE_RESOURCE_GROUP="dcos_testing_${BUILD_ID}"
 export LINUX_ADMIN="azureuser"
 export WIN_AGENT_PUBLIC_POOL="winpubpool"

--- a/DCOS/dcos-testing.sh
+++ b/DCOS/dcos-testing.sh
@@ -45,7 +45,7 @@ fi
 export LINUX_PRIVATE_IPS=""
 export WINDOWS_PRIVATE_IPS=""
 
-DIR=$(dirname $0)
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 MASTER_PUBLIC_ADDRESS="${LINUX_MASTER_DNS_PREFIX}.${AZURE_REGION}.cloudapp.azure.com"
 WIN_AGENT_PUBLIC_ADDRESS="${WIN_AGENT_DNS_PREFIX}.${AZURE_REGION}.cloudapp.azure.com"
 LINUX_AGENT_PUBLIC_ADDRESS="${LINUX_AGENT_DNS_PREFIX}.${AZURE_REGION}.cloudapp.azure.com"

--- a/DCOS/dcos-testing.sh
+++ b/DCOS/dcos-testing.sh
@@ -464,6 +464,9 @@ collect_dcos_nodes_logs() {
     # Collect logs from all the deployment nodes and upload them to the log server
     #
     echo "Collecting logs from all the DC/OS nodes"
+    if [[ ! -z $DCOS_CLUSTER_ID ]]; then
+        dcos node --json > $TEMP_LOGS_DIR/dcos-nodes.json
+    fi
 
     # Collect logs from all the Linux master node(s)
     echo "Collecting Linux master logs"
@@ -538,5 +541,4 @@ create_testing_environment() {
         echo "ERROR: Cannot find any cluster with the ID: $DCOS_CLUSTER_ID"
         return 1
     }
-    dcos node --json > $TEMP_LOGS_DIR/dcos-nodes.json
 }

--- a/DCOS/dcos-testing.sh
+++ b/DCOS/dcos-testing.sh
@@ -413,6 +413,7 @@ collect_windows_agents_logs() {
         AGENT_LOGS_DIR="/tmp/$IP"
         run_ssh_command $LINUX_ADMIN $MASTER_PUBLIC_ADDRESS "2200" "source /tmp/utils.sh && mount_smb_share $IP $WIN_AGENT_ADMIN $WIN_AGENT_ADMIN_PASSWORD && mkdir -p $AGENT_LOGS_DIR && cp -rf /mnt/$IP/AzureData $AGENT_LOGS_DIR/" || return 1
         run_ssh_command $LINUX_ADMIN $MASTER_PUBLIC_ADDRESS "2200" "if [[ -e /mnt/$IP/DCOS/environment ]]; then cp /mnt/$IP/DCOS/environment $AGENT_LOGS_DIR/; fi" || return 1
+        run_ssh_command $LINUX_ADMIN $MASTER_PUBLIC_ADDRESS "2200" "if [[ -e /mnt/$IP/Program\ Files/Docker/dockerd.log ]]; then cp /mnt/$IP/Program\ Files/Docker/dockerd.log $AGENT_LOGS_DIR/; fi" || return 1
         for SERVICE in "epmd" "mesos" "spartan"; do
             run_ssh_command $LINUX_ADMIN $MASTER_PUBLIC_ADDRESS "2200" "mkdir -p $AGENT_LOGS_DIR/$SERVICE && if [[ -e /mnt/$IP/DCOS/$SERVICE/log ]] ; then cp -rf /mnt/$IP/DCOS/$SERVICE/log $AGENT_LOGS_DIR/$SERVICE/ ; fi" || return 1
             run_ssh_command $LINUX_ADMIN $MASTER_PUBLIC_ADDRESS "2200" "if [[ -e /mnt/$IP/DCOS/$SERVICE/service/environment-file ]] ; then cp /mnt/$IP/DCOS/$SERVICE/service/environment-file $AGENT_LOGS_DIR/$SERVICE/ ; fi" || return 1

--- a/DCOS/dcos-testing.sh
+++ b/DCOS/dcos-testing.sh
@@ -206,6 +206,10 @@ test_mesos_fetcher() {
         echo "ERROR: Failed to get the Docker container ID from the host: $TASK_HOST"
         return 1
     }
+    if [[ -z $DOCKER_CONTAINER_ID ]]; then
+        echo "ERROR: There aren't any containers running on the Windows host: $TASK_HOST"
+        return 1
+    fi
     MD5_CHECKSUM=$(run_ssh_command $LINUX_ADMIN $MASTER_PUBLIC_ADDRESS "2200" "/tmp/wsmancmd.py -H $TASK_HOST -s -a basic -u $WIN_AGENT_ADMIN -p $WIN_AGENT_ADMIN_PASSWORD 'docker exec $DOCKER_CONTAINER_ID powershell (Get-FileHash -Algorithm MD5 -Path C:\mesos\sandbox\fetcher-test.zip).Hash'") || {
         echo "ERROR: Failed to get the fetcher file MD5 checksum"
         return 1


### PR DESCRIPTION
This pull request includes the following updates:

- Check if `DOCKER_CONTAINER_ID` is empty when trying to verify the fetcher file checksum from inside the Docker container
- Remove `BUILD_ID` variable set
- Copy environment file when collecting logs
- Remove any function calls from `dcos-testing.sh` script. From now on, this is meant to be sourced by the Jenkins job build script
- Save `dcos-nodes.json` when collecting logs
- Copy `dockerd.log` if present on the system. In the CI, we use the updated service wrapper to capture the stdout and stderr from the Docker daemon