### PR TITLE
Add '-UseBasicParsing' parameter to 'Invoke-WebRequest' calls

### DIFF
--- a/DCOS/autoscale-testing/AutoScale.Tests.ps1
+++ b/DCOS/autoscale-testing/AutoScale.Tests.ps1
@@ -48,14 +48,14 @@ function getMasterFQDN ($RG_NAME) {
 
 function getDCOSagentCount ($RG_NAME) {
     $masterFQDN = getMasterFQDN($RG_NAME)
-    $res = Invoke-WebRequest "http://$masterFQDN/dcos-history-service/history/last" | ConvertFrom-Json | Select-Object slaves
+    $res = Invoke-WebRequest -UseBasicParsing -Uri "http://$masterFQDN/dcos-history-service/history/last" | ConvertFrom-Json | Select-Object slaves
     $agentCount = $res.slaves.Count
     return $agentCount
 }
 
 function AreAllNodesHealthy ($RG_NAME) {
     $masterFQDN = getMasterFQDN($RG_NAME)
-    $res = Invoke-WebRequest "http://$masterFQDN/system/health/v1/nodes" | ConvertFrom-Json | Select-Object nodes
+    $res = Invoke-WebRequest -UseBasicParsing -Uri "http://$masterFQDN/system/health/v1/nodes" | ConvertFrom-Json | Select-Object nodes
     $isHealthy = $true
     foreach ($agentNode in $res.nodes) {
         if ($agentNode.health -ne 0) {
@@ -69,13 +69,13 @@ function AreAllNodesHealthy ($RG_NAME) {
 
 function AllMetricsGood ($RG_NAME) {
     $masterFQDN = getMasterFQDN($RG_NAME)
-    $res = Invoke-WebRequest "http://$masterFQDN/dcos-history-service/history/last" | ConvertFrom-Json | Select-Object slaves
+    $res = Invoke-WebRequest -UseBasicParsing -Uri "http://$masterFQDN/dcos-history-service/history/last" | ConvertFrom-Json | Select-Object slaves
     $isAllGood = $true
     foreach ($agentNode in $res.slaves) {
         Try
         {
             $agentMetricsRequestEp = "http://$masterFQDN/system/v1/agent/$($agentNode.id)/metrics/v0/node"
-            $dataPoints = Invoke-WebRequest $agentMetricsRequestEp | ConvertFrom-Json 
+            $dataPoints = Invoke-WebRequest -UseBasicParsing -Uri $agentMetricsRequestEp | ConvertFrom-Json 
             $dataPointCount = $dataPoints.datapoints.Count
 
             if ($dataPointCount -eq 0) {
@@ -157,7 +157,7 @@ Describe "Getting initial state" {
         $masterFQDN = $deployment.Outputs.masterFQDN.Value
         $masterFQDN | Should not be $null
         
-        $res = Invoke-WebRequest "http://$masterFQDN/dcos-history-service/history/last" | ConvertFrom-Json | Select-Object slaves
+        $res = Invoke-WebRequest -UseBasicParsing -Uri "http://$masterFQDN/dcos-history-service/history/last" | ConvertFrom-Json | Select-Object slaves
         $res | Should not be $null
         $res.slaves | Should not be $null
         $res.slaves.Count | Should BeGreaterThan 0

--- a/Diagnostics/start-windows-build.ps1
+++ b/Diagnostics/start-windows-build.ps1
@@ -49,7 +49,7 @@ function Install-Prerequisites {
         Write-Output "Downloading $program from $($prerequisites[$program]['url'])"
         $fileName = $prerequisites[$program]['url'].Split('/')[-1]
         $programFile = Join-Path $env:TEMP $fileName
-        Start-ExecuteWithRetry { Invoke-WebRequest -Uri $prerequisites[$program]['url'] -OutFile $programFile}
+        Start-ExecuteWithRetry { Invoke-WebRequest -UseBasicParsing -Uri $prerequisites[$program]['url'] -OutFile $programFile}
         $parameters = @{
             'FilePath' = $programFile
             'ArgumentList' = $prerequisites[$program]['install_args']

--- a/Metrics/start-windows-build.ps1
+++ b/Metrics/start-windows-build.ps1
@@ -49,7 +49,7 @@ function Install-Prerequisites {
         $fileName = $prerequisites[$program]['url'].Split('/')[-1]
         $programFile = Join-Path $env:TEMP $fileName
 
-        Start-ExecuteWithRetry { Invoke-WebRequest -Uri $prerequisites[$program]['url'] -OutFile $programFile}
+        Start-ExecuteWithRetry { Invoke-WebRequest -UseBasicParsing -Uri $prerequisites[$program]['url'] -OutFile $programFile}
         $parameters = @{
             'FilePath' = $programFile
             'ArgumentList' = $prerequisites[$program]['install_args']


### PR DESCRIPTION
This is needed otherwise we'll get the following error:

```
The response content cannot be parsed because the Internet Explorer engine is not available, or Internet Explorer's first-launch configuration is not complete.
Specify the UseBasicParsing parameter and try again.
```