### PR TITLE
Use latest insider build for DC/OS e2e testing

### DIFF
--- a/DCOS/acs-engine-dcos-deploy.sh
+++ b/DCOS/acs-engine-dcos-deploy.sh
@@ -21,8 +21,8 @@ validate_simple_deployment_params() {
     if [[ -z $WIN_AGENT_ADMIN ]]; then echo "ERROR: Parameter WIN_AGENT_ADMIN is not set"; exit 1; fi
     if [[ -z $WIN_AGENT_ADMIN_PASSWORD ]]; then echo "ERROR: Parameter WIN_AGENT_ADMIN_PASSWORD is not set"; exit 1; fi
 
-    if [[ ! -z $DCOS_VERSION ]] && [[ "$DCOS_VERSION" != "1.8.8" ]] && [[ "$DCOS_VERSION" != "1.9.0" ]] && [[ "$DCOS_VERSION" != "1.10.0" ]]; then
-        echo "ERROR: Supported DCOS_VERSION are: 1.8.8, 1.9.0 or 1.10.0"
+    if [[ ! -z $DCOS_VERSION ]] && [[ "$DCOS_VERSION" != "1.8.8" ]] && [[ "$DCOS_VERSION" != "1.9.0" ]] && [[ "$DCOS_VERSION" != "1.10.0" ]] && [[ "$DCOS_VERSION" != "1.11.0" ]]; then
+        echo "ERROR: Supported DCOS_VERSION are: 1.8.8, 1.9.0, 1.10.0 or 1.11.0"
         exit 1
     fi
     if [[ -z $DCOS_WINDOWS_BOOTSTRAP_URL ]]; then

--- a/DCOS/templates/acs-engine/testing/hybrid.json
+++ b/DCOS/templates/acs-engine/testing/hybrid.json
@@ -93,7 +93,8 @@
     ],
     "windowsProfile": {
       "adminUsername": "${WIN_AGENT_ADMIN}",
-      "adminPassword": "${WIN_AGENT_ADMIN_PASSWORD}"
+      "adminPassword": "${WIN_AGENT_ADMIN_PASSWORD}",
+      "WindowsImageSourceUrl": "https://mesosdcosci.blob.core.windows.net/windows-images/windows_server_insider_preview_latest.vhd"
     },
     "linuxProfile": {
       "adminUsername": "${LINUX_ADMIN}",


### PR DESCRIPTION
This pull requests adds the following updates:

- Latest Windows Server public insider build is used for DC/OS e2e testing
- Add `1.11.0` to the last of valid DC/OS releases for `DCOS/acs-engine-dcos-deploy.sh` script