### PR TITLE
Apply fixes from local patch file

### DIFF
--- a/Spartan/fixes.patch
+++ b/Spartan/fixes.patch
@@ -1,0 +1,42 @@
+From e961a75fb702a81fb73f18159f0996f1ad29762a Mon Sep 17 00:00:00 2001
+From: Ionut Balutoiu <ibalutoiu@cloudbasesolutions.com>
+Date: Fri, 13 Apr 2018 12:25:07 +0000
+Subject: [PATCH] Fixes
+
+* Add MASTERS_LIST_FILE environment variable
+* Decrease processes count from 10 to 1
+---
+ config/sys.config                    | 2 +-
+ src/spartan_config_loader_server.erl | 3 ++-
+ 2 files changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/config/sys.config b/config/sys.config
+index df1e14a..4f85b1f 100644
+--- a/config/sys.config
++++ b/config/sys.config
+@@ -21,7 +21,7 @@
+        {port, undefined}     %% for future db types
+       ]},
+       {servers, [
+-        [{name, inet_localhost_1}, {address, "127.0.0.1"}, {port, 62053}, {family, inet}, {processes, 10}]
++        [{name, inet_localhost_1}, {address, "127.0.0.1"}, {port, 62053}, {family, inet}, {processes, 1}]
+       ]},
+ 
+       {use_root_hints, false},
+diff --git a/src/spartan_config_loader_server.erl b/src/spartan_config_loader_server.erl
+index 5a1363f..098604f 100644
+--- a/src/spartan_config_loader_server.erl
++++ b/src/spartan_config_loader_server.erl
+@@ -126,7 +126,8 @@ get_masters() ->
+     end.
+ 
+ get_masters_file() ->
+-    {ok, FileBin} = file:read_file("/opt/mesosphere/etc/master_list"),
++    FileName = os:getenv("MASTER_LIST_FILE", "/opt/mesosphere/etc/master_list"),
++    {ok, FileBin} = file:read_file(FileName),
+     MastersBinIPs = jsx:decode(FileBin, [return_maps]),
+     IPAddresses = lists:map(fun spartan_app:parse_ipv4_address/1, MastersBinIPs),
+     {ok, [{IPAddress, ?MESOS_DNS_PORT} || IPAddress <- IPAddresses]}.
+-- 
+2.7.4
+

--- a/Spartan/start-windows-build.ps1
+++ b/Spartan/start-windows-build.ps1
@@ -113,15 +113,11 @@ function New-Environment {
     New-Directory $SPARTAN_BUILD_OUT_DIR
     New-Directory $SPARTAN_BUILD_LOGS_DIR
     Start-GitClone -URL $GitURL -Branch $Branch -Path $SPARTAN_GIT_REPO_DIR
+    # Apply fixes that are not upstream yet
+    Push-Location $SPARTAN_GIT_REPO_DIR
+    Start-ExternalCommand { git.exe am "$PSScriptRoot\fixes.patch" } -ErrorMessage "Failed to apply local patches"
+    Pop-Location
     $global:PARAMETERS["BRANCH"] = $Branch
-    #
-    # NOTE(ibalutoiu): Update the sys.config to use only a single process to
-    #                  spawn for the Spartan handler. Otherwise, during the
-    #                  common tests, Spartan will fail to start.
-    #
-    $configFile = Join-Path $SPARTAN_GIT_REPO_DIR "config\sys.config"
-    $newConfig = Get-Content $configFile | ForEach-Object { $_ -replace '{processes, 10}', '{processes, 1}' }
-    Set-Content -Path $configFile -Value $newConfig
     Set-LatestSpartanCommit
 }
 


### PR DESCRIPTION
Instead of building Spartan against a fork with fixes applied, we now apply those patches after cloning the upstream Spartan DC/OS repository.

NOTE: This PR will be reverted if these fixes will be included in the upstream repository already.