### PR TITLE
Added script for generating  adminrouter.zip

### DIFF
--- a/AdminRouter/README.md
+++ b/AdminRouter/README.md
@@ -1,0 +1,12 @@
+## AdminRouter Windows agent building and testing
+
+The process of testing the Adminrouter builds is done with the `start-windows-build.ps1` script and it can be broken into the following parts:
+
+* Install all the prerequisites necessary for the Windows AdminRouter build: git, and 7Zip
+* Create a new tests environment. At this step, the build directories are created and the three git repositories are clone (dcos-adminrouter, dcos-windows, and mesos-jenkins). 
+All repos are synced to the latest commit on master branch;
+* Build AdminRouter
+* Create/Copy config files for the adminrouter service
+* Compress above files into a adminrouter.zip
+
+At the end of any AdminRouter build (it doesn't matter if it was successful or not), all the build artifacts (logs and possible binaries) are uploaded to a separate log server.

--- a/AdminRouter/config/template.conf
+++ b/AdminRouter/config/template.conf
@@ -1,0 +1,143 @@
+
+ServerRoot "{{adminrouter_install_dir}}/{{apache_install_dir}}"
+
+Listen {{ adminrouter_port}}
+
+LoadModule access_compat_module modules/mod_access_compat.so
+LoadModule actions_module modules/mod_actions.so
+LoadModule alias_module modules/mod_alias.so
+LoadModule allowmethods_module modules/mod_allowmethods.so
+LoadModule asis_module modules/mod_asis.so
+LoadModule auth_basic_module modules/mod_auth_basic.so
+LoadModule authn_core_module modules/mod_authn_core.so
+LoadModule authn_file_module modules/mod_authn_file.so
+LoadModule authz_core_module modules/mod_authz_core.so
+LoadModule authz_groupfile_module modules/mod_authz_groupfile.so
+LoadModule authz_host_module modules/mod_authz_host.so
+LoadModule authz_user_module modules/mod_authz_user.so
+LoadModule autoindex_module modules/mod_autoindex.so
+LoadModule cgi_module modules/mod_cgi.so
+LoadModule dir_module modules/mod_dir.so
+LoadModule env_module modules/mod_env.so
+LoadModule include_module modules/mod_include.so
+LoadModule isapi_module modules/mod_isapi.so
+LoadModule log_config_module modules/mod_log_config.so
+LoadModule mime_module modules/mod_mime.so
+LoadModule negotiation_module modules/mod_negotiation.so
+LoadModule proxy_module modules/mod_proxy.so
+LoadModule proxy_http_module modules/mod_proxy_http.so
+LoadModule setenvif_module modules/mod_setenvif.so
+
+<IfModule unixd_module>
+User daemon
+Group daemon
+</IfModule>
+
+DocumentRoot "{{adminrouter_install_dir}}/{{apache_install_dir}}/htdocs"
+
+<Directory />
+    AllowOverride none
+    Require all denied
+</Directory>
+
+# Configures the footer on server-generated documents
+ServerSignature Off
+
+# Configures to send just "Server:Apache" in the Server HTTP response header 
+ServerTokens Prod
+
+<VirtualHost *:{{ adminrouter_port}}>
+    # Enforce 1024M request body max size limit for DC/OS 
+    LimitRequestBody 1073741824
+    # Set keepalive connections timeout for DC/OS
+    KeepAliveTimeout 65
+    # Settings for Apache proxy options
+    ProxyPreserveHost On
+    # Disable forward proxy
+    ProxyRequests Off
+    <Proxy *>
+        Order allow,deny
+        Allow from all
+    </Proxy>
+
+    # Proxy routing for DC/OS Metrics service
+    <Location /system/v1/metrics>
+        ProxyPass        http://localhost:{{local_metrics_port}}
+        ProxyPassReverse http://localhost:{{local_metrics_port}}
+    </Location>
+
+    # Proxy routing for DC/OS Dignostics service
+    <Location /system/health/v1>
+        ProxyPass        http://localhost:{{local_diagnostics_port}}/system/health/v1
+        ProxyPassReverse http://localhost:{{local_diagnostics_port}}/system/health/v1
+    </Location>
+    # Proxy routing for DC/OS Pkgpanda service
+    <Location /pkgpanda>
+        ProxyPass        http://localhost:{{local_pkgpanda_port}}
+        ProxyPassReverse http://localhost:{{local_pkgpanda_port}} 
+    </Location>
+    # Routing for DC/OS Logging service
+    <Location /system/v1/logs>
+        ProxyPass        http://localhost:{{local_logging_port}}
+        ProxyPassReverse http://localhost:{{local_logging_port}}
+    </Location>
+
+</VirtualHost>
+
+<IfModule dir_module>
+    DirectoryIndex index.html
+</IfModule>
+
+<Files ".ht*">
+    Require all denied
+</Files>
+
+ErrorLog "logs/error.log"
+LogLevel warn
+
+<IfModule log_config_module>
+    LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined
+    LogFormat "%h %l %u %t \"%r\" %>s %b" common
+
+    <IfModule logio_module>
+      LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\" %I %O" combinedio
+    </IfModule>
+    CustomLog "logs/access.log" common
+</IfModule>
+
+<IfModule alias_module>
+    ScriptAlias /cgi-bin/ "{{adminrouter_install_dir}}/{{apache_install_dir}}/cgi-bin/"
+</IfModule>
+
+<IfModule cgid_module>
+    #
+    # ScriptSock: On threaded servers, designate the path to the UNIX
+    # socket used to communicate with the CGI daemon of mod_cgid.
+    #
+    #Scriptsock cgisock
+</IfModule>
+
+<Directory "{{adminrouter_install_dir}}/{{apache_install_dir}}/cgi-bin">
+    AllowOverride None
+    Options None
+    Require all granted
+</Directory>
+
+<IfModule headers_module>
+    RequestHeader unset Proxy early
+</IfModule>
+
+<IfModule mime_module>
+    TypesConfig conf/mime.types
+    AddType application/x-compress .Z
+    AddType application/x-gzip .gz .tgz
+</IfModule>
+
+<IfModule proxy_html_module>
+Include conf/extra/proxy-html.conf
+</IfModule>
+
+<IfModule ssl_module>
+SSLRandomSeed startup builtin
+SSLRandomSeed connect builtin
+</IfModule>

--- a/AdminRouter/start-windows-build.ps1
+++ b/AdminRouter/start-windows-build.ps1
@@ -1,0 +1,284 @@
+Param(
+    [Parameter(Mandatory=$false)]
+    [string]$GitURL="https://github.com/apache/httpd", 
+    [Parameter(Mandatory=$false)]
+    [string]$Branch="master",
+    [Parameter(Mandatory=$false)]
+    [string]$CommitID,
+    [Parameter(Mandatory=$false)]
+    [string]$ParametersFile="${env:WORKSPACE}\build-parameters.json"
+)
+
+$ErrorActionPreference = "Stop"
+
+$globalVariables = (Resolve-Path "$PSScriptRoot\..\global-variables.ps1").Path
+$ciUtils = (Resolve-Path "$PSScriptRoot\..\Modules\CIUtils").Path
+
+Import-Module $ciUtils
+. $globalVariables
+
+$global:PARAMETERS = @{
+    "BUILD_STATUS" = $null
+    "LOGS_URLS" = @()
+    "FAILED_COMMAND" = $null
+}
+
+function Install-Prerequisites {
+    $prerequisites = @{
+        'git'= @{
+            'url'= $GIT_URL
+            'install_args' = @("/SILENT")
+            'install_dir' = $GIT_DIR
+        }
+        '7zip'= @{
+            'url'= $7ZIP_URL
+            'install_args'= @("/q")
+            'install_dir'= $7ZIP_DIR
+        }
+    }
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+    foreach($program in $prerequisites.Keys) {
+        if(Test-Path $prerequisites[$program]['install_dir']) {
+            Write-Output "$program is already installed"
+            continue
+        }
+        Write-Output "Downloading $program from $($prerequisites[$program]['url'])"
+        $fileName = $prerequisites[$program]['url'].Split('/')[-1]
+        $programFile = Join-Path $env:TEMP $fileName
+        Start-ExecuteWithRetry { Invoke-WebRequest -UseBasicParsing -Uri $prerequisites[$program]['url'] -OutFile $programFile} $RetryInterval 20
+        $parameters = @{
+            'FilePath' = $programFile
+            'ArgumentList' = $prerequisites[$program]['install_args']
+            'Wait' = $true
+            'PassThru' = $true
+        }
+        if($programFile.EndsWith('.msi')) {
+            $parameters['FilePath'] = 'msiexec.exe'
+            $parameters['ArgumentList'] += @("/i", $programFile)
+        }
+        Write-Output "Installing $programFile"
+        $p = Start-Process @parameters
+        if($p.ExitCode -ne 0) {
+            Throw "Failed to install prerequisite $programFile during the environment setup"
+        }
+    }
+    # Add all the tools to PATH
+    $toolsDirs = @("$GIT_DIR\cmd", "$GIT_DIR\bin", "$7ZIP_DIR")
+    $env:PATH += ';' + ($toolsDirs -join ';')
+}
+
+function Get-LatestCommitID {
+    return $global:LATEST_COMMIT_ID
+}
+
+function Set-LatestAdminRouterCommit {
+    # The following id is from https://www.apachelounge.com/download/VC15/binaries/httpd-2.4.33-win64-VC15.zip.txt
+    $commitId = $WINDOWS_APACHEL_HTTP_SERVER_SHA256
+    Set-Variable -Name "LATEST_COMMIT_ID" -Value $commitId -Scope Global  -Option ReadOnly
+}
+
+function Get-MesosJenkinsRepo {
+    Write-Output "Get-MesosJenkinsRepo"
+    New-Directory $ADMINROUTER_DIR | Out-Null
+    New-Directory $ADMINROUTER_BUILD_OUT_DIR -RemoveExisting | Out-Null
+    New-Directory $ADMINROUTER_BUILD_LOGS_DIR  -RemoveExisting | Out-Null
+    $global:PARAMETERS["BRANCH"] = $Branch
+    Remove-Item $ADMINROUTER_MESOS_JENKINS_GIT_REPO_DIR -Force  -Recurse -ErrorAction SilentlyContinue
+
+    Write-Output "Cloning Mesos-Jenkins repo"    
+    Start-GitClone -Path $ADMINROUTER_MESOS_JENKINS_GIT_REPO_DIR -URL $MESOS_JENKINS_GIT_URL -Branch $Branch
+    Write-Output "Cloning  done"
+}
+
+function Get-ApacheServerPackage {
+    Write-Output "Downloading Apache HTTP Server zip file: $WINDOWS_APACHEL_HTTP_SERVER_URL"
+    $filesPath = Join-Path $env:TEMP "httpd-2.4.33-win64-VC15.zip"
+    Start-ExecuteWithRetry { Invoke-WebRequest -UseBasicParsing -Uri $WINDOWS_APACHEL_HTTP_SERVER_URL -OutFile $filesPath}
+
+    # To be sure that a download is intact and has not been tampered with from the original download side
+    # we need to perform biniary hash validation
+    Write-Output "Validating Hash value for downloaded file: $filesPath"
+    $hashFromDowloadedFile = Get-FileHash $filesPath -Algorithm SHA256
+
+    # validate both hashes are the same
+    if ($hashFromDowloadedFile.Hash -eq $WINDOWS_APACHEL_HTTP_SERVER_SHA256) {
+        Write-Output 'Hash validation test passed'
+    } else {
+        Throw 'Hash validation test FAILED!!'
+    }
+
+    Write-Output "Extracting binaries archive in: $ADMINROUTER_DIR"
+    Expand-Archive -LiteralPath $filesPath -DestinationPath $ADMINROUTER_DIR -Force
+    Remove-item $filesPath
+    Write-Output "Finshed downloading"  
+    Set-LatestAdminRouterCommit
+}
+function Generate-AdminRouterConfigFromTemplate {
+    Param(
+        [Parameter(Mandatory=$true)]
+        [string]$TemplateFile,
+        [Parameter(Mandatory=$true)]
+        [string]$OutputFile
+    )
+     $context = @{
+        "adminrouter_install_dir" = ("$ADMINROUTER_FOR_TEMPLATE_DIR" -replace '\\', '/')
+        "adminrouter_port" = ("$ADMINROUTER_AGENT_PORT")
+        "local_metrics_port" = ("$METRICS_AGENT_PORT")
+        "local_diagnostics_port" = ("$DIAGNOSTICS_AGENT_PORT")
+        "local_pkgpanda_port" = ("$PKGPANDA_AGENT_PORT")
+        "local_logging_port" = ("$LOGGING_AGENT_PORT")
+        "apache_install_dir" = ("$ADMINROUTER_APACHE_DIR")
+    }
+    Start-RenderTemplate -TemplateFile $TemplateFile `
+                         -Context $context -OutFile $OutputFile
+}
+
+function New-DCOSAdminRouterPackage {
+    Write-Output "Generating DC/OS AdminRouter package $ADMINROUTER_ZIP_FILE_PATH"
+    New-Directory $ADMINROUTER_BUILD_BINARIES_DIR | Out-Null
+    Copy-Item -Recurse -Path "$ADMINROUTER_DIR\$ADMINROUTER_APACHE_DIR" -Destination $ADMINROUTER_BUILD_BINARIES_DIR | Out-Null
+
+    $template = "$ADMINROUTER_MESOS_JENKINS_GIT_REPO_DIR\AdminRouter\config\template.conf"
+    $configfile = "$ADMINROUTER_MESOS_JENKINS_GIT_REPO_DIR\AdminRouter\config\adminrouter.conf"
+    Generate-AdminRouterConfigFromTemplate -TemplateFile $template -OutputFile $configfile
+    Copy-Item -Recurse -Path "$ADMINROUTER_MESOS_JENKINS_GIT_REPO_DIR\AdminRouter\config\adminrouter.conf" -Destination "$ADMINROUTER_BUILD_BINARIES_DIR\$ADMINROUTER_APACHE_DIR\conf" | Out-Null
+
+    Compress-Files -FilesDirectory "$ADMINROUTER_BUILD_BINARIES_DIR\" -Filter "*.*" -Archive "$ADMINROUTER_ZIP_FILE_PATH"
+    Write-Output "DC/OS AdminRouter package was successfully generated"
+}
+
+function Copy-FilesToRemoteServer {
+    Param(
+        [Parameter(Mandatory=$true)]
+        [string]$LocalFilesPath,
+        [Parameter(Mandatory=$true)]
+        [string]$RemoteFilesPath
+    )
+    Write-Output "Started copying files from $LocalFilesPath to remote location at ${server}:${RemoteFilesPath}"
+    Start-SCPCommand -Server $REMOTE_LOG_SERVER -User $REMOTE_USER -Key $env:SSH_KEY `
+                     -LocalPath $LocalFilesPath -RemotePath $RemoteFilesPath
+}
+
+function New-RemoteDirectory {
+    Param(
+        [Parameter(Mandatory=$true)]
+        [string]$RemoteDirectoryPath
+    )
+    $remoteCMD = "if [[ -d $RemoteDirectoryPath ]]; then rm -rf $RemoteDirectoryPath; fi; mkdir -p $RemoteDirectoryPath"
+    Start-SSHCommand -Server $REMOTE_LOG_SERVER -User $REMOTE_USER -Key $env:SSH_KEY -Command $remoteCMD
+}
+
+function New-RemoteSymlink {
+    Param(
+        [Parameter(Mandatory=$true)]
+        [string]$RemotePath,
+        [Parameter(Mandatory=$false)]
+        [string]$RemoteSymlinkPath
+    )
+    $remoteCMD = "if [[ -h $RemoteSymlinkPath ]]; then unlink $RemoteSymlinkPath; fi; ln -s $RemotePath $RemoteSymlinkPath"
+    Start-SSHCommand -Server $REMOTE_LOG_SERVER -User $REMOTE_USER -Key $env:SSH_KEY -Command $remoteCMD
+}
+
+function Get-AdminRouterBuildRelativePath {
+    $repositoryOwner = $GitURL.Split("/")[-2]
+    $commitID = Get-LatestCommitID
+    return "$repositoryOwner/$Branch/$commitID"
+}
+
+function Get-RemoteBuildDirectoryPath {
+    $relativePath = Get-AdminRouterBuildRelativePath
+    return "$REMOTE_ADMINROUTER_BUILD_DIR/$relativePath"
+}
+
+function Get-BuildOutputsUrl {
+    $relativePath = Get-AdminRouterBuildRelativePath
+    return "$ADMINROUTER_BUILD_BASE_URL/$relativePath"
+}
+
+function New-RemoteLatestSymlinks {
+    $remoteDirPath = Get-RemoteBuildDirectoryPath
+    $baseDir = (Split-Path -Path $remoteDirPath -Parent) -replace '\\', '/'
+    New-RemoteSymlink -RemotePath $remoteDirPath -RemoteSymlinkPath "$baseDir/latest"
+    $repoDir = (Split-Path -Path $baseDir -Parent) -replace '\\', '/'
+    New-RemoteSymlink -RemotePath $remoteDirPath -RemoteSymlinkPath "$repoDir/latest"
+}
+
+function Start-LogServerFilesUpload {
+    $consoleUrl = "${JENKINS_SERVER_URL}/job/${env:JOB_NAME}/${env:BUILD_NUMBER}/consoleText"
+    Start-FileDownload -Force -URL $consoleUrl -Destination "$ADMINROUTER_BUILD_LOGS_DIR\console-jenkins.log"
+    $remoteDirPath = Get-RemoteBuildDirectoryPath
+    New-RemoteDirectory -RemoteDirectoryPath $remoteDirPath
+    Copy-FilesToRemoteServer "$ADMINROUTER_BUILD_OUT_DIR\*" $remoteDirPath
+    $buildOutputsUrl = Get-BuildOutputsUrl
+    $global:PARAMETERS["BUILD_OUTPUTS_URL"] = $buildOutputsUrl
+    Write-Output "Build artifacts can be found at: $buildOutputsUrl"
+    if($global:PARAMETERS["BUILD_STATUS"] -eq "PASS") {
+        New-RemoteLatestSymlinks
+    }
+ }
+
+function Start-EnvironmentCleanup {
+    cmd.exe /C "rmdir /s /q $ADMINROUTER_DIR > nul 2>&1"
+}
+
+function Get-SuccessBuildMessage {
+    return "Successful DC/OS AdminRouter Windows build and testing for repository $GitURL on $Branch branch"
+}
+
+function Start-TempDirCleanup {
+    Get-ChildItem $env:TEMP | Where-Object {
+        $_.Name -notmatch "^jna\-[0-9]*$|^hsperfdata.*_diagnostics$"
+    } | ForEach-Object {
+        $fullPath = $_.FullName
+        if($_.FullName -is [System.IO.DirectoryInfo]) {
+            cmd.exe /C "rmdir /s /q ${fullPath} > nul 2>&1"
+        } else {
+            cmd.exe /C "del /Q /S /F ${fullPath} > nul 2>&1"
+        }
+    }
+}
+
+function New-ParametersFile {
+    Param(
+        [Parameter(Mandatory=$true)]
+        [string]$FilePath
+    )
+    if(Test-Path $FilePath) {
+        Remove-Item -Force $FilePath
+    }
+    New-Item -ItemType File -Path $FilePath | Out-Null
+}
+
+function Write-ParametersFile {
+    Param(
+        [Parameter(Mandatory=$true)]
+        [string]$FilePath
+    )
+    if($global:PARAMETERS["LOGS_URLS"]) {
+        $global:PARAMETERS["LOGS_URLS"] = $global:PARAMETERS["LOGS_URLS"] -join '|'
+    }
+    $json = ConvertTo-Json -InputObject $global:PARAMETERS
+    Set-Content -Path $FilePath -Value $json
+}
+
+try {
+    Start-TempDirCleanup
+    New-ParametersFile -FilePath $ParametersFile
+    Install-Prerequisites
+    Get-MesosJenkinsRepo
+    Get-ApacheServerPackage
+    New-DCOSAdminRouterPackage
+    $global:PARAMETERS["BUILD_STATUS"] = "PASS"
+    $global:PARAMETERS["MESSAGE"] = Get-SuccessBuildMessage
+} catch {
+    Write-Output $_.ToString()
+    Write-Output $_.ScriptStackTrace
+    $global:PARAMETERS["BUILD_STATUS"] = "FAIL"
+    $global:PARAMETERS["MESSAGE"] = $_.ToString()
+    exit 1
+} finally {
+    Start-LogServerFilesUpload
+    Write-ParametersFile -FilePath $ParametersFile
+    Start-EnvironmentCleanup
+}
+exit 0

--- a/global-variables.ps1
+++ b/global-variables.ps1
@@ -8,6 +8,7 @@ $REMOTE_SPARTAN_BUILD_DIR = "/data/spartan-build"
 $REMOTE_DCOS_NET_BUILD_DIR = "/data/net-build"
 $REMOTE_DIAGNOSTICS_BUILD_DIR = "/data/diagnostics-build"
 $REMOTE_METRICS_BUILD_DIR = "/data/metrics-build"
+$REMOTE_ADMINROUTER_BUILD_DIR = "/data/adminrouter-build"
 
 # DCOS common configurations
 $LOG_SERVER_BASE_URL = "http://dcos-win.westus.cloudapp.azure.com"
@@ -87,6 +88,24 @@ $METRICS_DCOS_WINDOWS_GIT_REPO_DIR = Join-Path $METRICS_DIR "dcos-windows"
 $METRICS_MESOS_JENKINS_GIT_REPO_DIR = Join-Path $METRICS_DIR "mesos-jenkins"
 $METRICS_BUILD_BASE_URL = "$LOG_SERVER_BASE_URL/metrics-build"
 
+# AdminRouter configurations
+$ADMINROUTER_SERVICE_NAME = "dcos-adminrouter"
+$ADMINROUTER_AGENT_PORT = 61001
+$ADMINROUTER_FOR_TEMPLATE_DIR = "c:\DCOS\adminrouter"
+$ADMINROUTER_DIR = Join-Path $DCOS_DIR "adminrouter"
+$ADMINROUTER_GIT_REPO_DIR = Join-Path $ADMINROUTER_DIR "src\github.com\dcos\dcos-adminrouter"
+$ADMINROUTER_BUILD_OUT_DIR = Join-Path $ADMINROUTER_DIR "build-output"
+$ADMINROUTER_BUILD_LOGS_DIR = Join-Path $ADMINROUTER_BUILD_OUT_DIR "logs"
+$ADMINROUTER_BUILD_BINARIES_DIR = Join-Path $ADMINROUTER_BUILD_OUT_DIR "binaries"
+$ADMINROUTER_MESOS_JENKINS_GIT_REPO_DIR = Join-Path $ADMINROUTER_DIR "mesos-jenkins"
+$ADMINROUTER_BUILD_BASE_URL = "$LOG_SERVER_BASE_URL/adminrouter-build"
+$ADMINROUTER_APACHE_DIR = "Apache24"
+$ADMINROUTER_ZIP_FILE_PATH = Join-Path $ADMINROUTER_BUILD_BINARIES_DIR "adminrouter.zip"
+
+# Other ports
+$PKGPANDA_AGENT_PORT = 9001
+$LOGGING_AGENT_PORT = 9002
+
 # Installers & git repositories URLs
 $SERVICE_WRAPPER_URL = "$LOG_SERVER_BASE_URL/downloads/WinSW.NET4.exe"
 $VS2017_URL = "https://download.visualstudio.microsoft.com/download/pr/10930949/045b56eb413191d03850ecc425172a7d/vs_Community.exe"
@@ -103,6 +122,8 @@ $GOLANG_URL_1_94 = "https://dl.google.com/go/go1.9.4.windows-amd64.msi"
 $DCOS_WINDOWS_GIT_URL = "https://github.com/dcos/dcos-windows.git"
 $MESOS_JENKINS_GIT_URL = "https://github.com/Microsoft/mesos-jenkins.git"
 $LIBSODIUM_GIT_URL = "https://github.com/jedisct1/libsodium.git"
+$WINDOWS_APACHEL_HTTP_SERVER_URL = "https://www.apachelounge.com/download/VC15/binaries/httpd-2.4.33-win64-VC15.zip"
+$WINDOWS_APACHEL_HTTP_SERVER_SHA256 = "A9F94DBA6AFFE3BD98FEC01EF77DC932C123E25E360D29D970CC2CDD9F5BA237"
 
 # Tools installation directories
 $GIT_DIR = Join-Path $env:ProgramFiles "Git"


### PR DESCRIPTION
This PR contains changes that's needed for generating a adminrouter.zip file, which has all the Apache HTTP server files and matching configuration for setting up an AdminRouter on Windows agent node.

This is the first of a two parts checkin. The 2nd part will be posted to the dcos-windows for setting up the adminrouter on a Windows agent node.