### PR TITLE
Add e2e test for deploying marathon app with private image

### DIFF
--- a/DCOS/templates/marathon/private-iis.json
+++ b/DCOS/templates/marathon/private-iis.json
@@ -1,0 +1,49 @@
+{
+  "id": "test-private-iis",
+  "cmd": "powershell -Command while($true){Start-Sleep -Seconds 5}",
+  "cpus": 1,
+  "mem": 512,
+  "disk": 0,
+  "instances": 1,
+  "constraints": [
+    [
+      "os",
+      "LIKE",
+      "Windows"
+    ]
+  ],
+  "networks": [ { "mode": "container", "name": "customnat" } ],
+  "container": {
+    "type": "DOCKER",
+    "volumes": [],
+    "docker": {
+      "image": "dcoswindowsci/private-iis:17623",
+      "privileged": false,
+      "parameters": [
+        {
+          "key": "publish",
+          "value": "80:80"
+        }
+      ],
+      "forcePullImage": false
+    }
+  },
+  "healthChecks": [
+    {
+      "gracePeriodSeconds": 300,
+      "intervalSeconds": 60,
+      "timeoutSeconds": 20,
+      "maxConsecutiveFailures": 3,
+      "port": 80,
+      "path": "/",
+      "protocol": "MESOS_HTTP",
+      "ignoreHttp1xx": false
+    }
+  ],
+  "acceptedResourceRoles": [
+    "slave_public"
+  ],
+  "uris": [
+    "file://C:/docker.zip"
+  ]
+}


### PR DESCRIPTION
This commit adds a new e2e test for dcos marathon app.
It tries to deploy a marathon app using a private docker image and by passing the login credentials of the registry via the json app definition.