### PR TITLE
Updates for DC/OS end-to-end testing job

### DIFF
--- a/DCOS/README.md
+++ b/DCOS/README.md
@@ -3,13 +3,14 @@ The `acs-engine-dcos-deploy.sh` script is used to spawn a DC/OS environment in A
 Requirements:
 - Ubuntu >= 14.04;
 - [Azure CLI 2.0](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli);
-- Interactively login to Azure with the Azure CLI 2.0 in case the user has 2-way authentication enabled, otherwise the unattended login will fail.
+- Azure service principal account.
 
 Before running the script, some environment variables must be set. These are used as deployment config options by the script:
 
 ```
-export AZURE_USER="<azure_user>"
-export AZURE_USER_PASSWORD="<azure_password_value>"
+export AZURE_SERVICE_PRINCIPAL_ID="<service_principal_id>"
+export AZURE_SERVICE_PRINCIPAL_PASSWORD="<service_principal_password>"
+export AZURE_SERVICE_PRINCIPAL_TENAT="<service_principal_tenant>"
 export AZURE_REGION="westus"
 export AZURE_RESOURCE_GROUP="dcos_mesos_rg"
 

--- a/DCOS/acs-engine-dcos-deploy.sh
+++ b/DCOS/acs-engine-dcos-deploy.sh
@@ -130,12 +130,6 @@ rm -rf ./translations # Left-over after running 'acs-engine generate'
 DEPLOY_TEMPLATE_FILE="$DCOS_DEPLOY_DIR/azuredeploy.json"
 DEPLOY_PARAMS_FILE="$DCOS_DEPLOY_DIR/azuredeploy.parameters.json"
 
-# TODO(ibalutoiu): Remove these sed calls once the Windows version can be directly 
-#                  specified in the ACS template. This is temporary workaround
-#                  to enable RS3 deployments.
-sed -i 's|    "agentWindowsOffer": "WindowsServer",|    "agentWindowsOffer": "WindowsServerSemiAnnual",|g' $DEPLOY_TEMPLATE_FILE
-sed -i 's|    "agentWindowsSku": "2016-Datacenter-with-Containers",|    "agentWindowsSku": "Datacenter-Core-1709-with-Containers-smalldisk",|g' $DEPLOY_TEMPLATE_FILE
-
 azure_cli_login
 az group create -l "$AZURE_REGION" -n "$AZURE_RESOURCE_GROUP" -o table
 echo "Validating the DC/OS ARM deployment templates"

--- a/DCOS/acs-engine-dcos-deploy.sh
+++ b/DCOS/acs-engine-dcos-deploy.sh
@@ -5,8 +5,9 @@ CI_WEB_ROOT="http://dcos-win.westus.cloudapp.azure.com"
 
 
 validate_simple_deployment_params() {
-    if [[ -z $AZURE_USER ]]; then echo "ERROR: Parameter AZURE_USER is not set"; exit 1; fi
-    if [[ -z $AZURE_USER_PASSWORD ]]; then echo "ERROR: Parameter AZURE_USER_PASSWORD is not set"; exit 1; fi
+    if [[ -z $AZURE_SERVICE_PRINCIPAL_ID ]]; then echo "ERROR: Parameter AZURE_SERVICE_PRINCIPAL_ID is not set"; exit 1; fi
+    if [[ -z $AZURE_SERVICE_PRINCIPAL_PASSWORD ]]; then echo "ERROR: Parameter AZURE_SERVICE_PRINCIPAL_PASSWORD is not set"; exit 1; fi
+    if [[ -z $AZURE_SERVICE_PRINCIPAL_TENAT ]]; then echo "ERROR: Parameter AZURE_SERVICE_PRINCIPAL_TENAT is not set"; exit 1; fi
     if [[ -z $AZURE_REGION ]]; then echo "ERROR: Parameter AZURE_REGION is not set"; exit 1; fi
     if [[ -z $AZURE_RESOURCE_GROUP ]]; then echo "ERROR: Parameter AZURE_RESOURCE_GROUP is not set"; exit 1; fi
 
@@ -93,8 +94,11 @@ install_azure_cli_2() {
 }
 
 azure_cli_login() {
-    az account list --output json | grep -q "\"name\": \"$AZURE_USER\",$" && echo "Account is already logged" && return || echo "Logging with the user: $AZURE_USER"
-    az login -u $AZURE_USER -p $AZURE_USER_PASSWORD
+    if az account list --output json | jq -r '.[0]["user"]["name"]' | grep -q "^${AZURE_SERVICE_PRINCIPAL_ID}$"; then
+        echo "Account is already logged"
+        return
+    fi
+    az login --output table --service-principal -u $AZURE_SERVICE_PRINCIPAL_ID -p $AZURE_SERVICE_PRINCIPAL_PASSWORD --tenant $AZURE_SERVICE_PRINCIPAL_TENAT
 }
 
 # Check if all parameters are set

--- a/DCOS/acs-engine-dcos-deploy.sh
+++ b/DCOS/acs-engine-dcos-deploy.sh
@@ -135,9 +135,16 @@ DEPLOY_TEMPLATE_FILE="$DCOS_DEPLOY_DIR/azuredeploy.json"
 DEPLOY_PARAMS_FILE="$DCOS_DEPLOY_DIR/azuredeploy.parameters.json"
 
 azure_cli_login
-az group create -l "$AZURE_REGION" -n "$AZURE_RESOURCE_GROUP" -o table
+EXTRA_PARAMS=""
+if [[ "$DEBUG" = "true" ]]; then
+    EXTRA_PARAMS="$EXTRA_PARAMS --debug"
+fi
+if [[ "$VERBOSE" = "true" ]]; then
+    EXTRA_PARAMS="$EXTRA_PARAMS --verbose"
+fi
+az group create -l "$AZURE_REGION" -n "$AZURE_RESOURCE_GROUP" -o table $EXTRA_PARAMS
 echo "Validating the DC/OS ARM deployment templates"
-az group deployment validate -g "$AZURE_RESOURCE_GROUP" --template-file $DEPLOY_TEMPLATE_FILE --parameters @$DEPLOY_PARAMS_FILE -o table
+az group deployment validate -g "$AZURE_RESOURCE_GROUP" --template-file $DEPLOY_TEMPLATE_FILE --parameters @$DEPLOY_PARAMS_FILE -o table $EXTRA_PARAMS
 echo "Started the DC/OS deployment"
-az group deployment create -g "$AZURE_RESOURCE_GROUP" --template-file $DEPLOY_TEMPLATE_FILE --parameters @$DEPLOY_PARAMS_FILE -o table
+az group deployment create -g "$AZURE_RESOURCE_GROUP" --template-file $DEPLOY_TEMPLATE_FILE --parameters @$DEPLOY_PARAMS_FILE -o table $EXTRA_PARAMS
 rm -rf $DCOS_DEPLOY_DIR

--- a/DCOS/autoscale-testing/AutoScale.Tests.ps1
+++ b/DCOS/autoscale-testing/AutoScale.Tests.ps1
@@ -172,9 +172,13 @@ Describe "Getting initial state" {
         AreAllNodesHealthy($RG_NAME) |  Should be $true
     }
 
-    It "Are all nodes metric service running fine" {
-        AllMetricsGood($RG_NAME) |  Should be $true
-    }
+    ### TODO(ibalutoiu):
+    #   Enable metrics tests once dcos-metrics is running properly with Mesos
+    #   flag 'authenticate_agents' enabled.
+    #
+    # It "Are all nodes metric service running fine" {
+    #     AllMetricsGood($RG_NAME) |  Should be $true
+    # }
 }
 
 Describe "ScaleUp" {
@@ -206,9 +210,13 @@ Describe "ScaleUp" {
         AreAllNodesHealthy($RG_NAME) |  Should be $true
     }
 
-    It "Are all nodes metric service running fine" {
-        AllMetricsGood($RG_NAME) |  Should be $true
-    }     
+    ### TODO(ibalutoiu):
+    #   Enable metrics tests once dcos-metrics is running properly with Mesos
+    #   flag 'authenticate_agents' enabled.
+    #
+    # It "Are all nodes metric service running fine" {
+    #     AllMetricsGood($RG_NAME) |  Should be $true
+    # }
 }
 
 Describe "DCOS UI" {
@@ -313,7 +321,11 @@ Describe "ScaleDown" {
         AreAllNodesHealthy($RG_NAME) |  Should be $true
     } 
 
-    It "Are all nodes metric service running fine" {
-        AllMetricsGood($RG_NAME) |  Should be $true
-    }    
+    ### TODO(ibalutoiu):
+    #   Enable metrics tests once dcos-metrics is running properly with Mesos
+    #   flag 'authenticate_agents' enabled.
+    #
+    # It "Are all nodes metric service running fine" {
+    #     AllMetricsGood($RG_NAME) |  Should be $true
+    # }
 }

--- a/DCOS/dcos-testing.sh
+++ b/DCOS/dcos-testing.sh
@@ -677,11 +677,11 @@ create_testing_environment() {
     # - Configures the DC/OS clients for the current cluster and export the
     #   cluster ID as the DCOS_CLUSTER_ID environment variable
     #
-    sudo apt-get update -y &>/dev/null && sudo apt-get install jq python3-pip python3-virtualenv -y &>/dev/null || {
+    sudo apt-get update -y &>/dev/null && sudo apt-get install jq python3-pip python3-virtualenv virtualenv -y &>/dev/null || {
         echo "ERROR: Failed to install dependencies for the testing environment"
         return 1
     }
-    virtualenv -p python3 $VENV_DIR && . $VENV_DIR/bin/activate || {
+    python3 -m venv $VENV_DIR && . $VENV_DIR/bin/activate || {
         echo "ERROR: Failed to create the python3 virtualenv"
         return 1
     }

--- a/DCOS/dcos-testing.sh
+++ b/DCOS/dcos-testing.sh
@@ -283,11 +283,16 @@ test_iis_docker_private_image() {
     echo $DOCKER_HUB_USER_PASSWORD | docker --config $WORKSPACE/.docker/ login -u $DOCKER_HUB_USER --password-stdin || return 1
 
     # Create the zip archive
-    zip -r $WORKSPACE/docker.zip $WORKSPACE/.docker || return 1
+    pushd $WORKSPACE && zip -r docker.zip .docker && rm -rf .docker && popd || return 1
 
     # Upload docker.zip to master
     upload_files_via_scp $LINUX_ADMIN $MASTER_PUBLIC_ADDRESS "2200" "/tmp/docker.zip" "$WORKSPACE/docker.zip" || {
         echo "ERROR: Failed to scp docker.zip"
+        return 1
+    }
+
+    rm $WORKSPACE/docker.zip || {
+        echo "ERROR: Failed to clean up docker.zip"
         return 1
     }
 

--- a/DCOS/dcos-testing.sh
+++ b/DCOS/dcos-testing.sh
@@ -112,7 +112,7 @@ upload_logs() {
     # Uploads the logs to the log server
     #
     # Copy the Jenkins console as well
-    wget --no-check-certificate "${JENKINS_SERVER_URL}/job/${JOB_NAME}/${BUILD_NUMBER}/consoleText" -O $TEMP_LOGS_DIR/jenkins-console.log || return 1
+    curl "${JENKINS_SERVER_URL}/job/${JOB_NAME}/${BUILD_NUMBER}/consoleText" -o $TEMP_LOGS_DIR/jenkins-console.log || return 1
     echo "Uploading logs to the log server"
     upload_files_via_scp $LOG_SERVER_USER $LOG_SERVER_ADDRESS "22" "${REMOTE_LOGS_DIR}/" $TEMP_LOGS_DIR || return 1
     echo "All the logs available at: $BUILD_OUTPUTS_URL"

--- a/DCOS/dcos-testing.sh
+++ b/DCOS/dcos-testing.sh
@@ -99,7 +99,7 @@ job_cleanup() {
     fi
     if [[ "$RESOURCE_GROUP_CLEANUP" = "true" ]]; then
         echo "Deleting resource group: $AZURE_RESOURCE_GROUP"
-        az group delete --yes --name $AZURE_RESOURCE_GROUP --output table || {
+        az group delete --yes --no-wait --name $AZURE_RESOURCE_GROUP --output table || {
             echo "ERROR: Failed to delete the resource group"
             return 1
         }

--- a/DCOS/dcos-testing.sh
+++ b/DCOS/dcos-testing.sh
@@ -277,6 +277,7 @@ test_iis_docker_private_image() {
     #
     # Check if marathon can spawn a simple DC/OS IIS marathon application from a private docker image
     #
+    echo "Testing marathon applications with Docker private images"
 
     # Login to create the docker config file with credentials
     echo $DOCKER_HUB_USER_PASSWORD | docker --config $WORKSPACE/.docker/ login -u $DOCKER_HUB_USER --password-stdin || return 1
@@ -324,6 +325,7 @@ test_iis_docker_private_image() {
     }
     dcos marathon app show $APP_NAME > "${TEMP_LOGS_DIR}/dcos-marathon-${APP_NAME}-app-details.json"
     remove_dcos_marathon_app $APP_NAME || return 1
+    echo "Successfully tested marathon applications with Docker private images"
 }
 
 test_custom_attributes() {

--- a/DCOS/templates/acs-engine/stable/hybrid.json
+++ b/DCOS/templates/acs-engine/stable/hybrid.json
@@ -89,7 +89,10 @@
     ],
     "windowsProfile": {
       "adminUsername": "${WIN_AGENT_ADMIN}",
-      "adminPassword": "${WIN_AGENT_ADMIN_PASSWORD}"
+      "adminPassword": "${WIN_AGENT_ADMIN_PASSWORD}",
+      "WindowsPublisher": "MicrosoftWindowsServer",
+      "WindowsOffer": "WindowsServerSemiAnnual",
+      "WindowsSku": "Datacenter-Core-1709-with-Containers-smalldisk"
     },
     "linuxProfile": {
       "adminUsername": "${LINUX_ADMIN}",

--- a/DCOS/templates/acs-engine/stable/simple.json
+++ b/DCOS/templates/acs-engine/stable/simple.json
@@ -34,7 +34,10 @@
     ],
     "windowsProfile": {
       "adminUsername": "${WIN_AGENT_ADMIN}",
-      "adminPassword": "${WIN_AGENT_ADMIN_PASSWORD}"
+      "adminPassword": "${WIN_AGENT_ADMIN_PASSWORD}",
+      "WindowsPublisher": "MicrosoftWindowsServer",
+      "WindowsOffer": "WindowsServerSemiAnnual",
+      "WindowsSku": "Datacenter-Core-1709-with-Containers-smalldisk"
     },
     "linuxProfile": {
       "adminUsername": "${LINUX_ADMIN}",

--- a/DCOS/utils/utils.sh
+++ b/DCOS/utils/utils.sh
@@ -45,8 +45,7 @@ mount_smb_share() {
     local HOST=$1
     local USER=$2
     local PASS=$3
-    MOUNTED=$(df -h | grep -E "\/\/$HOST\/C\\$\s*")
-    if [[ "$MOUNTED" != "" ]]; then
+    if mount | awk '{print $3}' | grep -q "^\/mnt\/${HOST}$"; then
         return 0
     fi
     sudo mkdir -p /mnt/$HOST || return 1


### PR DESCRIPTION
This pull request includes the following updates:

* Set Windows Publisher, Offer and Sku for the DC/OS Windows agents
* Remove sed for agentWindowsOffer and agentWindowsSku
* Improve check for mounted path
* Add possibility to enable debug and verbose flags to `az deploy`
* Disable metrics Pester tests
* Disable `dcos-metrics` for all the Linux agents
* Fix `test_iis_docker_private_image`
* Add `--no-wait` parameter to `az group delete` command