### PR TITLE
Add Python 3 support for the python scripts

### DIFF
--- a/Mesos/utils/common.py
+++ b/Mesos/utils/common.py
@@ -17,10 +17,10 @@
 # limitations under the License.
 
 import json
-import urllib
-import urllib2
-
+import sys
 from datetime import datetime
+
+from python_compatibility_utils import urllib2, urlencode, decode_response
 
 REVIEWBOARD_URL = "https://reviews.apache.org"
 
@@ -42,11 +42,11 @@ class ReviewBoardHandler(object):
         if review_request["status"] != "submitted":
             review_ids.append(review_request["id"])
         else:
-            print ("The review request %s is already "
-                   "submitted" % (review_request["id"]))
+            print("The review request %s is already "
+                  "submitted" % (review_request["id"]))
         for review in review_request["depends_on"]:
             review_url = review["href"]
-            print "Dependent review: %s " % review_url
+            print("Dependent review: %s " % review_url)
             dependent_review = self.api(review_url)["review_request"]
             if dependent_review["id"] in review_ids:
                 raise ReviewError("Circular dependency detected for "
@@ -67,13 +67,11 @@ class ReviewBoardHandler(object):
                 opener = urllib2.build_opener(auth_handler)
                 urllib2.install_opener(opener)
                 self._opener_installed = True
-            return json.loads(urllib2.urlopen(url, data=data).read())
-        except urllib2.HTTPError as err:
-            print "Error handling URL %s: %s (%s)" % (url,
-                                                      err.reason,
-                                                      err.read())
-        except urllib2.URLError as err:
-            print "Error handling URL %s: %s" % (url, err.reason)
+            return json.loads(decode_response(urllib2.urlopen(url, data=data).read()))
+        except Exception as err:
+            print("Error handling URL %s: %s" % (url, err))
+            # raise the error after printing the message
+            raise
 
     def get_review_ids(self, review_request):
         """Returns the review requests' ids (together with any potential
@@ -94,28 +92,28 @@ class ReviewBoardHandler(object):
                             "types are: %s" % (text_type, valid_text_types))
         review_request_url = "%s/r/%s" % (REVIEWBOARD_URL,
                                           review_request['id'])
-        print "Posting to review request: %s\n%s" % (review_request_url,
-                                                     message)
+        print("Posting to review request: %s\n%s" % (review_request_url,
+                                                     message))
         review_url = review_request["links"]["reviews"]["href"]
-        data = urllib.urlencode({'body_top': message,
+        data = urlencode({'body_top': message,
                                  'body_top_text_type': text_type,
                                  'public': 'true'})
         self.api(review_url, data)
 
     def needs_verification(self, review_request):
         """Return True if this review request needs to be verified."""
-        print "Checking if review: %s needs verification" % (
-            review_request["id"])
+        print("Checking if review: %s needs verification" % (
+            review_request["id"]))
         rb_date_format = "%Y-%m-%dT%H:%M:%SZ"
 
         # Now apply this review if not yet submitted.
         if review_request["status"] == "submitted":
-            print "The review is already already submitted"
+            print("The review is already already submitted")
             return False
 
         # Skip if the review blocks another review.
         if review_request["blocks"]:
-            print "Skipping blocking review %s" % review_request["id"]
+            print("Skipping blocking review %s" % review_request["id"])
             return False
 
         # Get the timestamp of the latest review from this script.
@@ -126,11 +124,11 @@ class ReviewBoardHandler(object):
             if review["links"]["user"]["title"] == self.user:
                 timestamp = review["timestamp"]
                 review_time = datetime.strptime(timestamp, rb_date_format)
-                print "Latest review timestamp: %s" % review_time
+                print("Latest review timestamp: %s" % review_time)
                 break
         if not review_time:
             # Never reviewed, the review request needs to be verified
-            print "Patch never verified, needs verification"
+            print("Patch never verified, needs verification")
             return True
 
         # Every patch must have a diff
@@ -140,10 +138,10 @@ class ReviewBoardHandler(object):
         # Get the timestamp of the latest diff.
         timestamp = latest_diff["diff"]["timestamp"]
         diff_time = datetime.strptime(timestamp, rb_date_format)
-        print "Latest diff timestamp: %s" % diff_time
+        print("Latest diff timestamp: %s" % diff_time)
         if review_time < diff_time:
             # There is a new diff, needs verification
-            print "There is a new diff, needs verification"
+            print("There is a new diff, needs verification")
             return True
 
         # TODO: Apply this check recursively up the dependency chain.
@@ -154,7 +152,7 @@ class ReviewBoardHandler(object):
             if "depends_on" in change["fields_changed"]:
                 timestamp = change["timestamp"]
                 dependency_time = datetime.strptime(timestamp, rb_date_format)
-                print "Latest dependency change timestamp: %s" % (
+                print("Latest dependency change timestamp: %s" %
                     dependency_time)
                 break
 
@@ -172,20 +170,20 @@ class GearmanClient(object):
     def check_gearman_request_status(self, job_request):
         import gearman
         if job_request.complete:
-            print "Job %s finished!\n%s" % (job_request.job.unique,
-                                            job_request.result)
+            print("Job %s finished!\n%s" % (job_request.job.unique,
+                                            job_request.result))
         elif job_request.timed_out:
-            print "Job %s timed out!" % job_request.job.unique
+            print("Job %s timed out!" % job_request.job.unique)
         elif job_request.state == gearman.JOB_UNKNOWN:
-            print "Job %s connection failed!" % job_request.unique
+            print("Job %s connection failed!" % job_request.unique)
 
     def trigger_gearman_jobs(self):
         import gearman
         if len(self.servers) == 0:
             raise Exception("No gearman servers to trigger the jobs")
-        print "Using the following Gearman servers: %s" % self.servers
+        print("Using the following Gearman servers: %s" % self.servers)
         client = gearman.GearmanClient(self.servers)
-        print "Triggered all the jobs and waiting them to finish"
+        print("Triggered all the jobs and waiting them to finish")
         completed_job_requests = client.submit_multiple_jobs(
             jobs_to_submit=self.jobs, wait_until_complete=True,
             max_retries=0, poll_timeout=None)

--- a/Mesos/utils/post-build-result.py
+++ b/Mesos/utils/post-build-result.py
@@ -19,11 +19,9 @@
 import argparse
 import os
 import sys
-import urllib2
-
-sys.path.append(os.getcwd())
 
 from common import ReviewBoardHandler, REVIEWBOARD_URL # noqa
+from python_compatibility_utils import urllib2
 
 LOG_TAIL_LIMIT = 30
 

--- a/Mesos/utils/python_compatibility_utils.py
+++ b/Mesos/utils/python_compatibility_utils.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+
+if sys.version_info.major == 3:
+    # for Python 3
+    import urllib.request as urllib2
+    from urllib.parse import urlencode
+else:
+    # for Python 2
+    import urllib2
+    from urllib import urlencode
+
+
+def decode_response(data):
+    # Takes the data received from urlopen(...).read() and returns it as a
+    # string.
+    if sys.version_info.major == 3:
+        # On Python 3 the response is encoded as bytes, the response needs
+        # to be decoded as string. Default encoding is utf-8
+        return data.decode(sys.getdefaultencoding())
+    else:
+        # Nothing to do on Python 2, there string and bytes are the same type
+        return data

--- a/Mesos/utils/trigger-gearman-jobs.py
+++ b/Mesos/utils/trigger-gearman-jobs.py
@@ -23,8 +23,6 @@ import sys
 import uuid
 import time
 
-sys.path.append(os.getcwd())
-
 from common import GearmanClient # noqa
 
 DEFAULT_GEARMAN_PORT = 4730
@@ -48,8 +46,8 @@ def parse_parameters():
 def main():
     """Main function to verify the submitted reviews."""
     parameters = parse_parameters()
-    print "\n%s - Running %s" % (time.strftime('%m-%d-%y_%T'),
-                                 os.path.abspath(__file__))
+    print("\n%s - Running %s" % (time.strftime('%m-%d-%y_%T'),
+                                 os.path.abspath(__file__)))
     servers = []
     for server in parameters.servers.split(","):
         server = server.strip()
@@ -65,7 +63,7 @@ def main():
     }
     if parameters.params is not None:
         job_params.update(json.loads(parameters.params))
-    print "Triggering %s" % (parameters.job)
+    print("Triggering %s" % (parameters.job))
     task_name = "build:%s" % parameters.job
     jobs = [dict(unique=uuid.uuid4().hex,
                  task=task_name,

--- a/Mesos/utils/verify-review-requests.py
+++ b/Mesos/utils/verify-review-requests.py
@@ -23,11 +23,9 @@ import sys
 import uuid
 import time
 import datetime
-import urllib
-
-sys.path.append(os.getcwd())
 
 from common import ReviewBoardHandler, GearmanClient, ReviewError, REVIEWBOARD_URL # noqa
+from python_compatibility_utils import urlencode
 
 DEFAULT_GEARMAN_PORT = 4730
 MESOS_REPOSITORY_ID = 122
@@ -82,7 +80,7 @@ def parse_parameters():
 
 def verify_reviews(review_ids, parameters):
     nr_reviews = len(review_ids)
-    print "There are %s review requests that need verification" % nr_reviews
+    print("There are %s review requests that need verification" % nr_reviews)
     if hasattr(parameters, 'out_file'):
         # Using file plug-in
         with open(parameters.out_file, 'w') as f:
@@ -105,7 +103,7 @@ def verify_reviews(review_ids, parameters):
     jobs = []
     task_name = "build:%s" % parameters.job
     for review_id in review_ids:
-        print "Preparing build job with review id: %s" % review_id
+        print("Preparing build job with review id: %s" % review_id)
         job_params = {
             'REVIEW_ID': review_id,
             "OFFLINE_NODE_WHEN_COMPLETE": "false"
@@ -124,11 +122,11 @@ def verify_reviews(review_ids, parameters):
 def main():
     """Main function to verify the submitted reviews."""
     parameters = parse_parameters()
-    print "\n%s - Running %s" % (time.strftime('%m-%d-%y_%T'),
-                                 os.path.abspath(__file__))
+    print("\n%s - Running %s" % (time.strftime('%m-%d-%y_%T'),
+                                 os.path.abspath(__file__)))
     # The colon from timestamp gets encoded and we don't want it to be encoded.
     # Replacing %3A with colon.
-    query_string = urllib.urlencode(json.loads(parameters.query)).replace("%3A", ":")
+    query_string = urlencode(json.loads(parameters.query)).replace("%3A", ":")
     review_requests_url = "%s/api/review-requests/?%s" % (REVIEWBOARD_URL,
                                                           query_string)
     handler = ReviewBoardHandler(parameters.user, parameters.password)


### PR DESCRIPTION
This patch adds a new file called "python_compatibility_utils.py"
which contains the imports and methods that work on both
Python 2 and 3. It exposes the same name for functions and modules,
making it easy to use in other parts of the code.

It also adds brackets to the message from print function as that
is mandatory in Python 3.

Adds __init__.py file to be able to import from current directory
without adding the current directory to system path.