### PR TITLE
Remove custom cmd from marathon templates

### DIFF
--- a/DCOS/templates/marathon/fetcher-http.json
+++ b/DCOS/templates/marathon/fetcher-http.json
@@ -1,6 +1,5 @@
 {
   "id": "test-fetcher-http",
-  "cmd": "powershell -Command while($true){Start-Sleep -Seconds 5}",
   "cpus": 1,
   "mem": 512,
   "disk": 0,

--- a/DCOS/templates/marathon/fetcher-https.json
+++ b/DCOS/templates/marathon/fetcher-https.json
@@ -1,6 +1,5 @@
 {
   "id": "test-fetcher-https",
-  "cmd": "powershell -Command while($true){Start-Sleep -Seconds 5}",
   "cpus": 1,
   "mem": 512,
   "disk": 0,

--- a/DCOS/templates/marathon/fetcher-local.json
+++ b/DCOS/templates/marathon/fetcher-local.json
@@ -1,6 +1,5 @@
 {
   "id": "test-fetcher-local",
-  "cmd": "powershell -Command while($true){Start-Sleep -Seconds 5}",
   "cpus": 1,
   "mem": 512,
   "disk": 0,

--- a/DCOS/templates/marathon/iis.json
+++ b/DCOS/templates/marathon/iis.json
@@ -1,6 +1,5 @@
 {
   "id": "test-iis",
-  "cmd": "powershell -Command while($true){Start-Sleep -Seconds 5}",
   "cpus": 1,
   "mem": 512,
   "disk": 0,

--- a/DCOS/templates/marathon/private-iis.json
+++ b/DCOS/templates/marathon/private-iis.json
@@ -1,6 +1,5 @@
 {
   "id": "test-private-iis",
-  "cmd": "powershell -Command while($true){Start-Sleep -Seconds 5}",
   "cpus": 1,
   "mem": 512,
   "disk": 0,

--- a/DCOS/templates/marathon/windows-app.json
+++ b/DCOS/templates/marathon/windows-app.json
@@ -1,6 +1,5 @@
 {
   "id": "test-windows-app",
-  "cmd": "powershell -Command while($true){Start-Sleep -Seconds 5}",
   "cpus": 1,
   "mem": 512,
   "disk": 0,


### PR DESCRIPTION
We need to use the [default cmd](https://github.com/Microsoft/iis-docker/blob/master/nanoserver-sac2016/Dockerfile#L19) given when using the official microsoft/iis Docker image.