### PR TITLE
do not disable dcos-checks-poststart when disabling dcos-metrics-agent

### DIFF
--- a/DCOS/regression-testing/src/script/disable_linux_agents_dcos_metrics.sh
+++ b/DCOS/regression-testing/src/script/disable_linux_agents_dcos_metrics.sh
@@ -5,7 +5,7 @@ set -e
 set -u
 set -o pipefail
 
-echo "Disabling dcos-metrics and dcos-checks-poststart on all the Linux agents"
+echo "Disabling dcos-metrics on all the Linux agents"
 
 SSH_KEY=${SSH_KEY:-"${OUTPUT}/id_rsa"}
 
@@ -19,25 +19,27 @@ done
 IPS="$PRIVATE_IPS"
 
 if [[ -z $IPS ]]; then
-  return 0
+  exit 0
 fi
 
-declare -a cmds=(
-  "sudo systemctl stop dcos-metrics-agent.service || echo skipped"
-  "sudo systemctl stop dcos-metrics-agent.socket || echo skipped"
-  "sudo systemctl disable dcos-metrics-agent.service || echo skipped"
-  "sudo systemctl disable dcos-metrics-agent.socket || echo skipped"
-  "sudo systemctl stop dcos-checks-poststart.timer || echo skipped"
-  "sudo systemctl stop dcos-checks-poststart.service || echo skipped"
-  "sudo systemctl disable dcos-checks-poststart.timer || echo skipped"
-  "sudo systemctl disable dcos-checks-poststart.service || echo skipped")
+master_scp="scp -i ${SSH_KEY} -o ConnectTimeout=30 -o StrictHostKeyChecking=no -P 2200"
+master_ssh="ssh -i ${SSH_KEY} -o ConnectTimeout=30 -o StrictHostKeyChecking=no -p 2200 azureuser@${INSTANCE_NAME}.${LOCATION}.cloudapp.azure.com"
+agent_ssh="ssh -i /tmp/id_rsa -o ConnectTimeout=30 -o StrictHostKeyChecking=no"
 
-scp -i ${SSH_KEY} -o ConnectTimeout=30 -o StrictHostKeyChecking=no -P 2200 ${SSH_KEY} azureuser@${INSTANCE_NAME}.${LOCATION}.cloudapp.azure.com:/tmp/id_rsa
+$master_scp ${SSH_KEY} azureuser@${INSTANCE_NAME}.${LOCATION}.cloudapp.azure.com:/tmp/id_rsa
 
-ssh_cmd="ssh -o ConnectTimeout=30 -o StrictHostKeyChecking=no"
 for IP in $IPS; do
-  for CMD in "${cmds[@]}"; do
-    $ssh_cmd -i ${SSH_KEY} -p 2200 azureuser@${INSTANCE_NAME}.${LOCATION}.cloudapp.azure.com "$ssh_cmd -i /tmp/id_rsa azureuser@$IP $CMD"
-  done
+  $master_ssh "$agent_ssh azureuser@$IP sudo systemctl stop dcos-metrics-agent.socket"
+  $master_ssh "$agent_ssh azureuser@$IP sudo systemctl disable dcos-metrics-agent.socket"
+  $master_ssh "$agent_ssh azureuser@$IP sudo systemctl stop dcos-metrics-agent.service"
+  $master_ssh "$agent_ssh azureuser@$IP sudo systemctl disable dcos-metrics-agent.service"
+  json=$($master_ssh "$agent_ssh azureuser@$IP cat /opt/mesosphere/etc/dcos-diagnostics-runner-config.json")
+  tmpfile=$(mktemp)
+  echo $json | jq 'del(.node_checks.checks.mesos_agent_registered_with_masters)' > $tmpfile
+  $master_scp $tmpfile azureuser@${INSTANCE_NAME}.${LOCATION}.cloudapp.azure.com:$tmpfile
+  $master_ssh "scp -i /tmp/id_rsa -o ConnectTimeout=30 -o StrictHostKeyChecking=no $tmpfile azureuser@$IP:$tmpfile"
+  $master_ssh "$agent_ssh azureuser@$IP sudo cp $tmpfile /opt/mesosphere/etc/dcos-diagnostics-runner-config.json"
+  $master_ssh "$agent_ssh azureuser@$IP sudo systemctl restart dcos-checks-poststart.service"
+  rm $tmpfile
 done
-echo "Successfully disabled dcos-metrics and dcos-checks-poststart on all the Linux agents"
+echo "Successfully disabled dcos-metrics on all the Linux agents"


### PR DESCRIPTION
instead of disabling dcos-checks-poststart, remove dcos-metrics section from the configuration file