### PR TITLE
Updates for DC/OS e2e testing job

### DIFF
--- a/DCOS/templates/marathon/fetcher-http.json
+++ b/DCOS/templates/marathon/fetcher-http.json
@@ -16,7 +16,7 @@
     "type": "DOCKER",
     "volumes": [],
     "docker": {
-      "image": "microsoft/iis",
+      "image": "microsoft/iis:windowsservercore-1803",
       "privileged": false,
       "portMappings": [
         {

--- a/DCOS/templates/marathon/fetcher-https.json
+++ b/DCOS/templates/marathon/fetcher-https.json
@@ -16,7 +16,7 @@
     "type": "DOCKER",
     "volumes": [],
     "docker": {
-      "image": "microsoft/iis",
+      "image": "microsoft/iis:windowsservercore-1803",
       "privileged": false,
       "portMappings": [
         {

--- a/DCOS/templates/marathon/fetcher-local.json
+++ b/DCOS/templates/marathon/fetcher-local.json
@@ -16,7 +16,7 @@
     "type": "DOCKER",
     "volumes": [],
     "docker": {
-      "image": "microsoft/iis",
+      "image": "microsoft/iis:windowsservercore-1803",
       "privileged": false,
       "portMappings": [
         {

--- a/DCOS/templates/marathon/iis.json
+++ b/DCOS/templates/marathon/iis.json
@@ -16,7 +16,7 @@
     "type": "DOCKER",
     "volumes": [],
     "docker": {
-      "image": "microsoft/iis",
+      "image": "microsoft/iis:windowsservercore-1803",
       "privileged": false,
       "parameters": [
         {

--- a/DCOS/templates/marathon/private-iis.json
+++ b/DCOS/templates/marathon/private-iis.json
@@ -16,7 +16,7 @@
     "type": "DOCKER",
     "volumes": [],
     "docker": {
-      "image": "dcoswindowsci/private-iis:17623",
+      "image": "dcoswindowsci/private-iis:17134",
       "privileged": false,
       "parameters": [
         {

--- a/DCOS/templates/marathon/windows-app.json
+++ b/DCOS/templates/marathon/windows-app.json
@@ -16,7 +16,7 @@
     "type": "DOCKER",
     "volumes": [],
     "docker": {
-      "image": "microsoft/iis",
+      "image": "microsoft/iis:windowsservercore-1803",
       "privileged": false,
       "portMappings": [
         {


### PR DESCRIPTION
* Use 1803 Docker images in all the marathon templates
* Do not disable `dcos-checks-poststart` when disabling `dcos-metrics`
* Fix `test_windows_agent_dcos_dns`