### PR TITLE
Added config file for the Windows Metrics Service

### DIFF
--- a/Metrics/config/dcos-metrics-config.yaml
+++ b/Metrics/config/dcos-metrics-config.yaml
@@ -1,0 +1,23 @@
+##############################################
+# Configuration file for dcos-metrics service
+# for Windows agent node
+##############################################
+
+  # Collector configuration
+  collector:
+    http_profiler: false
+
+    node:
+      poll_period: 60s
+
+    mesos_agent:
+      poll_period: 60s
+      port: 5051
+      request_protocol: http
+      request_timeout: 30s
+
+  # Producers configuration
+  producers:
+    # HTTP producer
+    http:
+      port: 9000

--- a/Metrics/start-windows-build.ps1
+++ b/Metrics/start-windows-build.ps1
@@ -144,6 +144,7 @@ function New-TestingEnvironment {
     Start-GitClone -Path $METRICS_GIT_REPO_DIR -URL $GitURL -Branch $Branch
     Set-LatestMetricsCommit
     Start-GitClone -Path $METRICS_DCOS_WINDOWS_GIT_REPO_DIR -URL $DCOS_WINDOWS_GIT_URL
+    Start-GitClone -Path $METRICS_MESOS_JENKINS_GIT_REPO_DIR -URL $MESOS_JENKINS_GIT_URL
     $env:GOPATH = $METRICS_DIR
     $goBinPath = Join-Path $GOLANG_DIR "bin"
     [System.Environment]::SetEnvironmentVariable('GOBIN', $goBinPath)
@@ -183,6 +184,7 @@ function New-DCOSMetricsPackage {
     $clusterid | Set-Content $MetricsClusterIdFile
     Copy-Item -Path "$METRICS_DCOS_WINDOWS_GIT_REPO_DIR\scripts\detect_ip.ps1" -Destination $METRICS_BUILD_BINARIES_DIR
     Copy-Item -Force -Path "$METRICS_GIT_REPO_DIR\*.exe" -Destination "$METRICS_BUILD_BINARIES_DIR\"
+    Copy-Item -Recurse -Path "$METRICS_MESOS_JENKINS_GIT_REPO_DIR\Metrics\config" -Destination "$METRICS_BUILD_BINARIES_DIR\config"
     Compress-Files -FilesDirectory "$METRICS_BUILD_BINARIES_DIR\" -Filter "*.*" -Archive "$METRICS_BUILD_BINARIES_DIR\metrics.zip"
     Write-Output "DC/OS Metrics package was successfully generated at $METRICS_BUILD_BINARIES_DIR\metrics.zip"
 }
@@ -354,8 +356,8 @@ try {
     $global:PARAMETERS["MESSAGE"] = $_.ToString()
     exit 1
 } finally {
-   Start-LogServerFilesUpload
-   Write-ParametersFile -FilePath $ParametersFile
-   Start-EnvironmentCleanup
+    Start-LogServerFilesUpload
+    Write-ParametersFile -FilePath $ParametersFile
+    Start-EnvironmentCleanup
 }
 exit 0


### PR DESCRIPTION
This PR contains the first of the two steps for addressing the following issue:
Adding the config file into the metrics.xip file
https://github.com/dcos/dcos-windows/issues/71

There will be a separate PR for dcos-windows repro for using this new config file in the metrics service.
