### PR TITLE
DC/OS end to end testing job updates

### DIFF
--- a/DCOS/acs-engine-dcos-deploy.sh
+++ b/DCOS/acs-engine-dcos-deploy.sh
@@ -93,8 +93,8 @@ EOF
 acs-engine generate --output-directory $DCOS_DEPLOY_DIR $ACS_RENDERED_TEMPLATE
 rm -rf ./translations # Left-over after running 'acs-engine generate'
 
-if [[ ! -z $CURRENT_BUILD_ARTIFACTS_DIR ]] && [[ -d $CURRENT_BUILD_ARTIFACTS_DIR ]]; then
-    cp -rf $DCOS_DEPLOY_DIR ${CURRENT_BUILD_ARTIFACTS_DIR}/
+if [[ ! -z $BUILD_ARTIFACTS_DIR ]] && [[ -d $BUILD_ARTIFACTS_DIR ]]; then
+    cp -rf $DCOS_DEPLOY_DIR ${BUILD_ARTIFACTS_DIR}/
 fi
 
 # Deploy the DC/OS with Mesos environment

--- a/DCOS/dcos-testing.sh
+++ b/DCOS/dcos-testing.sh
@@ -685,7 +685,7 @@ linux_agents_private_ips() {
     }
     PRIVATE_IPS=""
     for VMSS_NAME in $VMSS_NAMES; do
-        IPS=$(az vmss nic list --resource-group $AZURE_RESOURCE_GROUP --vmss-name $VMSS_NAME | jq -r ".[] | .ipConfigurations[0].privateIpAddress") || {
+        IPS=$(az vmss nic list --resource-group $AZURE_RESOURCE_GROUP --vmss-name $VMSS_NAME | jq -r ".[] | select(.virtualMachine != null) | .ipConfigurations[0].privateIpAddress") || {
             echo "ERROR: Failed to get VMSS $VMSS_NAME private addresses"
             return 1
         }
@@ -706,7 +706,7 @@ windows_agents_private_ips() {
     }
     PRIVATE_IPS=""
     for VMSS_NAME in $VMSS_NAMES; do
-        IPS=$(az vmss nic list --resource-group $AZURE_RESOURCE_GROUP --vmss-name $VMSS_NAME | jq -r ".[] | .ipConfigurations[0].privateIpAddress") || {
+        IPS=$(az vmss nic list --resource-group $AZURE_RESOURCE_GROUP --vmss-name $VMSS_NAME | jq -r ".[] | select(.virtualMachine != null) | .ipConfigurations[0].privateIpAddress") || {
             echo "ERROR: Failed to get VMSS $VMSS_NAME private addresses"
             return 1
         }

--- a/DCOS/dcos-testing.sh
+++ b/DCOS/dcos-testing.sh
@@ -59,13 +59,14 @@ if [[ ! -d $JOB_ARTIFACTS_DIR ]]; then
     echo "The job artifacts directory $JOB_ARTIFACTS_DIR does not exist. Creating it"
     mkdir -p $JOB_ARTIFACTS_DIR
 fi
-export CURRENT_BUILD_ARTIFACTS_DIR="${JOB_ARTIFACTS_DIR}/${BUILD_ID}"
-if [[ -e $CURRENT_BUILD_ARTIFACTS_DIR ]]; then
-    echo "ArtIfacts directory for current build exists. Deleting it"
-    rm -rf $CURRENT_BUILD_ARTIFACTS_DIR
+export BUILD_ARTIFACTS_DIR="${JOB_ARTIFACTS_DIR}/${BUILD_ID}"
+if [[ -e $BUILD_ARTIFACTS_DIR ]]; then
+    echo "Build artifacts directory $BUILD_ARTIFACTS_DIR already exists. Deleting it and creating a new one"
+    rm -rf $BUILD_ARTIFACTS_DIR
 fi
-echo "Creating artifacts directory for this build"
-mkdir -p $CURRENT_BUILD_ARTIFACTS_DIR
+echo "Creating a new build artifacts directory at $BUILD_ARTIFACTS_DIR"
+mkdir -p $BUILD_ARTIFACTS_DIR
+
 # LINUX_PRIVATE_IPS and WINDOWS_PRIVATE_IPS will be set later on in the script
 export LINUX_PRIVATE_IPS=""
 export WINDOWS_PRIVATE_IPS=""

--- a/DCOS/dcos-testing.sh
+++ b/DCOS/dcos-testing.sh
@@ -577,13 +577,10 @@ test_dcos_dns() {
 }
 
 test_master_agent_authentication() {
+    PYTHON_SCRIPT="import json,sys; input = json.load(sys.stdin); print(input['flags']['authenticate_agents'])"
     for i in `seq 0 $(($LINUX_MASTER_COUNT - 1))`; do
         MASTER_SSH_PORT="220$i"
-        run_ssh_command -i $GENERATED_SSH_KEY_PATH -u $LINUX_ADMIN -h $MASTER_PUBLIC_ADDRESS -p $MASTER_SSH_PORT -c  'sudo apt install jq -y' || {
-            echo "ERROR: Failed to install jq on the master $i"
-            return 1
-        }
-        AUTH_ENABLED=$(run_ssh_command -i $GENERATED_SSH_KEY_PATH -u $LINUX_ADMIN -h $MASTER_PUBLIC_ADDRESS -p $MASTER_SSH_PORT -c  'curl -s http://$(/opt/mesosphere/bin/detect_ip):5050/flags | jq -r ".flags.authenticate_agents"') || {
+        AUTH_ENABLED=$(run_ssh_command -i $GENERATED_SSH_KEY_PATH -u $LINUX_ADMIN -h $MASTER_PUBLIC_ADDRESS -p $MASTER_SSH_PORT -c "curl -s http://\$(/opt/mesosphere/bin/detect_ip):5050/flags | python -c \"${PYTHON_SCRIPT}\"") || {
             echo "ERROR: Failed to find the Mesos flags on the master $i"
             return 1
         }

--- a/DCOS/dcos-testing.sh
+++ b/DCOS/dcos-testing.sh
@@ -51,15 +51,15 @@ fi
 if [[ -z $DCOS_DIR ]]; then
     export DCOS_DIR="$WORKSPACE/dcos_$BUILD_ID"
 fi
-if [[ -z $BUILDS_ARTIFACTS_DIR ]]; then
-    echo "ERROR: BUILDS_ARTIFACTS_DIR is not set"
+if [[ -z $JOB_ARTIFACTS_DIR ]]; then
+    echo "ERROR: JOB_ARTIFACTS_DIR is not set"
     exit 1
 fi
-if [[ ! -d $BUILDS_ARTIFACTS_DIR ]]; then
-    echo "Builds artifacts directory does not exist. Creating it"
-    mkdir -p $BUILDS_ARTIFACTS_DIR
+if [[ ! -d $JOB_ARTIFACTS_DIR ]]; then
+    echo "The job artifacts directory $JOB_ARTIFACTS_DIR does not exist. Creating it"
+    mkdir -p $JOB_ARTIFACTS_DIR
 fi
-export CURRENT_BUILD_ARTIFACTS_DIR="${BUILDS_ARTIFACTS_DIR}/${BUILD_ID}"
+export CURRENT_BUILD_ARTIFACTS_DIR="${JOB_ARTIFACTS_DIR}/${BUILD_ID}"
 if [[ -e $CURRENT_BUILD_ARTIFACTS_DIR ]]; then
     echo "ArtIfacts directory for current build exists. Deleting it"
     rm -rf $CURRENT_BUILD_ARTIFACTS_DIR

--- a/DCOS/dcos-testing.sh
+++ b/DCOS/dcos-testing.sh
@@ -122,7 +122,10 @@ create_linux_ssh_keypair() {
         return 1
     }
     # Convert ssh key to base64 first and remove newlines
-    base64  "$GENERATED_SSH_KEY_PATH" | tr -d '\n' >  "${GENERATED_SSH_KEY_PATH}.b64"
+    base64  "$GENERATED_SSH_KEY_PATH" | tr -d '\n' >  "${GENERATED_SSH_KEY_PATH}.b64" || {
+        echo "ERROR: Failed to create SSH key base64 file: ${GENERATED_SSH_KEY_PATH}.b64"
+        return 1
+    }
     # Upload private/public keys as secrets to Azure key vault
     az keyvault secret set --vault-name "$AZURE_KEYVAULT_NAME" --name "$PRIVATE_KEY_SECRET_NAME" --file "${GENERATED_SSH_KEY_PATH}.b64" &>/dev/null || {
         echo "ERROR: Failed to upload private key to Azure key vault $AZURE_KEYVAULT_NAME"

--- a/DCOS/dcos-testing.sh
+++ b/DCOS/dcos-testing.sh
@@ -781,16 +781,11 @@ check_exit_code() {
 create_testing_environment() {
     #
     # - Create the python3 virtual environment and activate it
-    # - Installs the DC/OS client packages
     # - Configures the DC/OS clients for the current cluster and export the
     #   cluster ID as the DCOS_CLUSTER_ID environment variable
     #
-    python3 -m venv $VENV_DIR && . $VENV_DIR/bin/activate || {
+    python3 -m venv $VENV_DIR --system-site-packages && . $VENV_DIR/bin/activate || {
         echo "ERROR: Failed to create the python3 virtualenv"
-        return 1
-    }
-    pip3 install -U dcos dcoscli || {
-        echo "ERROR: Failed to install the DC/OS pip client packages"
         return 1
     }
     rm -rf $DCOS_DIR || return 1

--- a/DCOS/utils/update-dcos-diagnostics-runner-config.py
+++ b/DCOS/utils/update-dcos-diagnostics-runner-config.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+
+import json
+import sys
+
+config_file = '/opt/mesosphere/etc/dcos-diagnostics-runner-config.json'
+with open(config_file, 'r') as f:
+    config_str = f.read()
+
+config_json = json.loads(config_str)
+config_json['node_checks']['checks'].pop('mesos_agent_registered_with_masters')
+
+print(json.dumps(config_json, indent=2))


### PR DESCRIPTION
* Remove `jq` dependency
* Use python `wsmancmd` self-contained Linux binary
* Use `dcos` and `dcoscli` from the system python packages
* Get only the private IPs attached to a virtual machine
* Rename some environment variables
* Add error checking for base64 file creation