### PR TITLE
Added user-to-framework authentication for marathon.

### DIFF
--- a/DCOS/templates/preprovision/extensions/preprovision-master-linux/v1/preprovision-master-linux.sh
+++ b/DCOS/templates/preprovision/extensions/preprovision-master-linux/v1/preprovision-master-linux.sh
@@ -18,3 +18,6 @@ echo "[Service]
 Environment=MESOS_CREDENTIALS=/etc/ethos/dcos-mesos-master-secrets
 Environment=MESOS_AUTHENTICATE_AGENTS=true" > /etc/systemd/system/dcos-mesos-master.service.d/10-dcos-mesos-authentication.conf
 
+mkdir -p /etc/systemd/system/dcos-marathon.service.d
+echo "[Service]
+Environment=MESOSPHERE_HTTP_CREDENTIALS=frameworkuser:frameworkpassword" > /etc/systemd/system/dcos-marathon.service.d/10-dcos-marathon-authentication.conf


### PR DESCRIPTION
This will require users to enter a username/password to log into the framework (dcos-ui/marathon).