### PR TITLE
WIP: Use Python 3 version of `apply-reviews.py` script.

### DIFF
--- a/Mesos/start-windows-build.ps1
+++ b/Mesos/start-windows-build.ps1
@@ -169,8 +169,9 @@ function Add-ReviewBoardPatch {
             } else {
                 $buildErrorMsg = "Failed to apply the dependent review: $id."
             }
+            # TODO(andschwa): Move this back to `support\apply-reviews.py` after the Python 2 deprecation is complete.
             Start-MesosCIProcess -ProcessPath "python.exe" -StdoutFileName "apply-review-${id}-stdout.log" -StderrFileName "apply-review-${id}-stderr.log" `
-                                 -ArgumentList @(".\support\apply-reviews.py", "-n", "-r", $id) -BuildErrorMessage $buildErrorMsg
+                                 -ArgumentList @(".\support\python3\apply-reviews.py", "-n", "-r", $id) -BuildErrorMessage $buildErrorMsg
         } finally {
             Pop-Location
         }


### PR DESCRIPTION
Hi @ionutbalutoiu!

The new Python 3 versions of all the scripts are now upstream, at `support/python3/<name-of-script>`. I tried updating this, but didn't quite see how I make sure `C:\Program Files\Python36\python.exe` was in the path. I found:

```
Jenkins/set-up-windows-jenkins-build-server.ps1
29:    "python36" = @{
283:function Install-Python36 {
284:    $installDir = Join-Path $env:ProgramFiles "Python36"
285:    Install-CITool -InstallerPath $PACKAGES["python36"]["local_file"] `
445:    Install-Python36
```

But that didn't help me much. Would you be able to make the correct changes to use Python 3 with this special copy of the script? Thanks :)