### PR TITLE
Updated Marathon templates for the regression-testing

### DIFF
--- a/DCOS/regression-testing/src/iis-rs3-marathon-template.json
+++ b/DCOS/regression-testing/src/iis-rs3-marathon-template.json
@@ -7,7 +7,7 @@
   "constraints": [
     [ "os", "LIKE", "Windows"]
   ],
-  "networks": [ { "mode": "container", "name": "customnat" } ],
+  "networks": [ { "mode": "container", "name": "dcosnat" } ],
   "container": {
     "type": "DOCKER",
     "volumes": [],

--- a/DCOS/regression-testing/src/iis-rs4-marathon-template.json
+++ b/DCOS/regression-testing/src/iis-rs4-marathon-template.json
@@ -7,7 +7,7 @@
   "constraints": [
     [ "os", "LIKE", "Windows"]
   ],
-  "networks": [ { "mode": "container", "name": "customnat" } ],
+  "networks": [ { "mode": "container", "name": "dcosnat" } ],
   "container": {
     "type": "DOCKER",
     "volumes": [],


### PR DESCRIPTION
This is just a sync with the latest updates to the DC/OS Windows setup scripts: https://github.com/dcos/dcos-windows/pull/84