### PR TITLE
Fetch the CI DCOSWindowsAgentSetup.ps1 script

### DIFF
--- a/AgentBlob/GenerateAgentBlob.ps1
+++ b/AgentBlob/GenerateAgentBlob.ps1
@@ -110,7 +110,6 @@ function New-DCOSWindowsAgentBlob {
             Throw "Failed to clone $SETUP_SCRIPTS_REPO_URL repository"
         }
     } -RetryMessage "Failed to clone ${SETUP_SCRIPTS_REPO_URL}"
-    Copy-Item "${setupScripts}\scripts\DCOSWindowsAgentSetup.ps1" $ARTIFACTS_DIR
     Write-Log "Creating zip package from $blobDir"
     $blobTargetPath = Join-Path $ARTIFACTS_DIR $WINDOWS_AGENT_BLOB_FILE_NAME
     if(Test-Path $blobTargetPath) {

--- a/AgentBlob/PublishTestingAgentBlob.ps1
+++ b/AgentBlob/PublishTestingAgentBlob.ps1
@@ -58,6 +58,13 @@ function Publish-BuildArtifacts {
     if((Get-ChildItem $ArtifactsDirectory).Count -eq 0) {
         Throw "The artifacts directory is empty"
     }
+    # Fetch the CI init script before publishing artifacts
+    $ciInitScriptUrl = "https://raw.githubusercontent.com/Microsoft/mesos-jenkins/master/DCOS/DCOSWindowsAgentSetup.ps1"
+    $ciInitScript = "${ArtifactsDirectory}\DCOSWindowsAgentSetup.ps1"
+    curl.exe --keepalive-time 2 -fLsS --retry 10 -Y 100000 -y 60 -L -o $ciInitScript $ciInitScriptUrl
+    if($LASTEXITCODE) {
+        Throw "Fail to download $ciInitScriptUrl"
+    }
     $remoteBuildDir = "${REMOTE_BASE_DIR}/${ReleaseVersion}"
     New-RemoteDirectory -RemoteDirectoryPath $remoteBuildDir
     Copy-FilesToRemoteServer "${ArtifactsDirectory}\*" $remoteBuildDir


### PR DESCRIPTION
Get the CI `DCOSWindowsAgentSetup.ps1` script before publishing testing artifacts.