### PR TITLE
DC/OS e2e testing updates

### DIFF
--- a/DCOS/DCOSWindowsAgentSetup.ps1
+++ b/DCOS/DCOSWindowsAgentSetup.ps1
@@ -148,6 +148,12 @@ try {
     }
 
     #
+    # Pre-pull CI IIS image
+    #
+    Start-ExecuteWithRetry -ScriptBlock { docker.exe pull "microsoft/iis:windowsservercore-1803" } `
+                           -MaxRetryCount 30 -RetryInterval 3 -RetryMessage "Failed to pull IIS image. Retrying"
+
+    #
     # Enable Docker debug logging and capture stdout and stderr to a file.
     # We're using the updated service wrapper for this.
     #

--- a/DCOS/dcos-testing.sh
+++ b/DCOS/dcos-testing.sh
@@ -86,7 +86,6 @@ LOG_SERVER_ADDRESS="dcos-win.westus.cloudapp.azure.com"
 LOG_SERVER_USER="jenkins"
 REMOTE_LOGS_DIR="/data/dcos-testing"
 LOGS_BASE_URL="http://dcos-win.westus.cloudapp.azure.com/dcos-testing"
-JENKINS_SERVER_URL="https://mesos-jenkins.westus2.cloudapp.azure.com"
 UTILS_FILE="$DIR/utils/utils.sh"
 BUILD_OUTPUTS_URL="$LOGS_BASE_URL/$BUILD_ID"
 PARAMETERS_FILE="$WORKSPACE/build-parameters.txt"
@@ -203,7 +202,7 @@ upload_logs() {
     # Uploads the logs to the log server
     #
     # Copy the Jenkins console as well
-    curl "${JENKINS_SERVER_URL}/job/${JOB_NAME}/${BUILD_NUMBER}/consoleText" -o $TEMP_LOGS_DIR/jenkins-console.log || return 1
+    curl --user ${JENKINS_USER}:${JENKINS_PASSWORD} "${JENKINS_URL}/job/${JOB_NAME}/${BUILD_NUMBER}/consoleText" -o $TEMP_LOGS_DIR/jenkins-console.log || return 1
     echo "Uploading logs to the log server"
     upload_files_via_scp -u $LOG_SERVER_USER -h $LOG_SERVER_ADDRESS -p "22" -f "${REMOTE_LOGS_DIR}/" $TEMP_LOGS_DIR || return 1
     echo "All the logs available at: $BUILD_OUTPUTS_URL"
@@ -836,7 +835,14 @@ run_dcos_autoscale_job() {
     AUTOSCALE_EXIT_CODE=$?
     AUTOSCALE_JOB_NUMBER=$(echo $OUTPUT | grep -Eo '[0-9]+' | head -1)
 
-    echo "You can check the Jenkins console at: ${JENKINS_SERVER_URL}/job/${AUTOSCALE_JOB_NAME}/${AUTOSCALE_JOB_NUMBER}/console"
+    JOB_URL="${JENKINS_URL}/job/${AUTOSCALE_JOB_NAME}/${AUTOSCALE_JOB_NUMBER}"
+    echo "Finished $JOB_URL"
+
+    echo "Console output from the scale testing job:"
+    curl --user ${JENKINS_USER}:${JENKINS_PASSWORD} "${JOB_URL}/consoleText" || {
+        echo "Failed to download scale test console log"
+        return 1
+    }
 
     if [[ $AUTOSCALE_EXIT_CODE -ne 0 ]]; then
         echo "DC/OS autoscale testing job failed"

--- a/DCOS/dcos-testing.sh
+++ b/DCOS/dcos-testing.sh
@@ -903,5 +903,7 @@ successfully_exit_dcos_testing_job() {
         rm -f $PARAMETERS_FILE
     fi
 
+    echo "Ending time: $(date)"
+
     echo "Successfully tested an Azure DC/OS deployment with the latest DC/OS builds"
 }

--- a/Diagnostics/start-windows-build.ps1
+++ b/Diagnostics/start-windows-build.ps1
@@ -242,8 +242,9 @@ function New-RemoteLatestSymlinks {
 }
 
 function Start-LogServerFilesUpload {
-    $consoleUrl = "${JENKINS_SERVER_URL}/job/${env:JOB_NAME}/${env:BUILD_NUMBER}/consoleText"
-    Start-FileDownload -Force -URL $consoleUrl -Destination "$DIAGNOSTICS_BUILD_LOGS_DIR\console-jenkins.log"
+    $consoleUrl = "${JENKINS_URL}/job/${env:JOB_NAME}/${env:BUILD_NUMBER}/consoleText"
+    Start-FileDownload -User ${env:JENKINS_USER} -Password ${env:JENKINS_PASSWORD} `
+                       -URL $consoleUrl -Destination "$DIAGNOSTICS_BUILD_LOGS_DIR\console-jenkins.log"
     $remoteDirPath = Get-RemoteBuildDirectoryPath
     New-RemoteDirectory -RemoteDirectoryPath $remoteDirPath
     Copy-FilesToRemoteServer "$DIAGNOSTICS_BUILD_OUT_DIR\*" $remoteDirPath

--- a/Mesos/start-windows-build.ps1
+++ b/Mesos/start-windows-build.ps1
@@ -318,8 +318,9 @@ function New-RemoteLatestSymlinks {
 }
 
 function Start-LogServerFilesUpload {
-    $consoleUrl = "${JENKINS_SERVER_URL}/job/${env:JOB_NAME}/${env:BUILD_NUMBER}/consoleText"
-    Start-FileDownload -Force -URL $consoleUrl -Destination "$MESOS_BUILD_LOGS_DIR\console-jenkins.log"
+    $consoleUrl = "${JENKINS_URL}/job/${env:JOB_NAME}/${env:BUILD_NUMBER}/consoleText"
+    Start-FileDownload -User ${env:JENKINS_USER} -Password ${env:JENKINS_PASSWORD} `
+                       -URL $consoleUrl -Destination "$MESOS_BUILD_LOGS_DIR\console-jenkins.log"
     $remoteDirPath = Get-RemoteBuildDirectoryPath
     New-RemoteDirectory -RemoteDirectoryPath $remoteDirPath
     $tempDir = Join-Path $env:TEMP "build-output"

--- a/Metrics/start-windows-build.ps1
+++ b/Metrics/start-windows-build.ps1
@@ -256,8 +256,9 @@ function New-RemoteLatestSymlinks {
 }
 
 function Start-LogServerFilesUpload {
-    $consoleUrl = "${JENKINS_SERVER_URL}/job/${env:JOB_NAME}/${env:BUILD_NUMBER}/consoleText"
-    Start-FileDownload -Force -URL $consoleUrl -Destination "$METRICS_BUILD_LOGS_DIR\console-jenkins.log"
+    $consoleUrl = "${JENKINS_URL}/job/${env:JOB_NAME}/${env:BUILD_NUMBER}/consoleText"
+    Start-FileDownload -User ${env:JENKINS_USER} -Password ${env:JENKINS_PASSWORD} `
+                       -URL $consoleUrl -Destination "$METRICS_BUILD_LOGS_DIR\console-jenkins.log"
     $remoteDirPath = Get-RemoteBuildDirectoryPath
     New-RemoteDirectory -RemoteDirectoryPath $remoteDirPath
     Copy-FilesToRemoteServer "$METRICS_BUILD_OUT_DIR\*" $remoteDirPath

--- a/Net/start-windows-build.ps1
+++ b/Net/start-windows-build.ps1
@@ -311,8 +311,9 @@ function New-RemoteLatestSymlinks {
 }
 
 function Start-LogServerFilesUpload {
-    $consoleUrl = "${JENKINS_SERVER_URL}/job/${env:JOB_NAME}/${env:BUILD_NUMBER}/consoleText"
-    Start-FileDownload -Force -URL $consoleUrl -Destination "$DCOS_NET_BUILD_LOGS_DIR\console-jenkins.log"
+    $consoleUrl = "${JENKINS_URL}/job/${env:JOB_NAME}/${env:BUILD_NUMBER}/consoleText"
+    Start-FileDownload -User ${env:JENKINS_USER} -Password ${env:JENKINS_PASSWORD} `
+                       -URL $consoleUrl -Destination "$DCOS_NET_BUILD_LOGS_DIR\console-jenkins.log"
     $remoteDirPath = Get-RemoteBuildDirectoryPath
     New-RemoteDirectory -RemoteDirectoryPath $remoteDirPath
     Copy-FilesToRemoteServer "$DCOS_NET_BUILD_OUT_DIR\*" $remoteDirPath

--- a/Spartan/start-windows-build.ps1
+++ b/Spartan/start-windows-build.ps1
@@ -199,8 +199,9 @@ function New-RemoteSymlink {
 }
 
 function Start-LogServerFilesUpload {
-    $consoleUrl = "${JENKINS_SERVER_URL}/job/${env:JOB_NAME}/${env:BUILD_NUMBER}/consoleText"
-    Start-FileDownload -Force -URL $consoleUrl -Destination "$SPARTAN_BUILD_LOGS_DIR\console-jenkins.log"
+    $consoleUrl = "${JENKINS_URL}/job/${env:JOB_NAME}/${env:BUILD_NUMBER}/consoleText"
+    Start-FileDownload -User ${env:JENKINS_USER} -Password ${env:JENKINS_PASSWORD} `
+                       -URL $consoleUrl -Destination "$SPARTAN_BUILD_LOGS_DIR\console-jenkins.log"
     $remoteDirPath = Get-RemoteBuildDirectoryPath
     New-RemoteDirectory -RemoteDirectoryPath $remoteDirPath
     Copy-FilesToRemoteServer "$SPARTAN_BUILD_OUT_DIR\*" $remoteDirPath

--- a/global-variables.ps1
+++ b/global-variables.ps1
@@ -1,5 +1,3 @@
-$JENKINS_SERVER_URL="https://mesos-jenkins.westus2.cloudapp.azure.com"
-
 # Remote log server
 $REMOTE_LOG_SERVER = "dcos-win.westus.cloudapp.azure.com"
 $REMOTE_USER = "jenkins"


### PR DESCRIPTION
* Pre-pull IIS image for the CI tests
* Add ending time log in `succesfully_exit_dcos_testing_job`
* Switch `Start-FileDownload` to use `curl.exe`
* Add credentials when fetching the Jenkins console