### PR TITLE
Fix typo

### DIFF
--- a/AgentBlob/PublishTestingAgentBlob.ps1
+++ b/AgentBlob/PublishTestingAgentBlob.ps1
@@ -64,7 +64,7 @@ function Publish-BuildArtifacts {
         Remove-Item -Recurse -Force $ciScripts
     }
     Start-ExecuteWithRetry -ScriptBlock {
-        $p = Start-Process -FilePath 'git.exe' -Wait -PassThru -NoNewWindow -ArgumentList @('clone', $MESOS_JENKINS_GIT_URL, $setupScripts)
+        $p = Start-Process -FilePath 'git.exe' -Wait -PassThru -NoNewWindow -ArgumentList @('clone', $MESOS_JENKINS_GIT_URL, $ciScripts)
         if($p.ExitCode -ne 0) {
             Throw "Failed to clone $MESOS_JENKINS_GIT_URL repository"
         }


### PR DESCRIPTION
This fixes a typo error for `AgentBlob/PublishTestingAgentBlob.ps1`