### PR TITLE
Add missing `env:` preffix

### DIFF
--- a/Diagnostics/start-windows-build.ps1
+++ b/Diagnostics/start-windows-build.ps1
@@ -242,7 +242,7 @@ function New-RemoteLatestSymlinks {
 }
 
 function Start-LogServerFilesUpload {
-    $consoleUrl = "${JENKINS_URL}/job/${env:JOB_NAME}/${env:BUILD_NUMBER}/consoleText"
+    $consoleUrl = "${env:JENKINS_URL}/job/${env:JOB_NAME}/${env:BUILD_NUMBER}/consoleText"
     Start-FileDownload -User ${env:JENKINS_USER} -Password ${env:JENKINS_PASSWORD} `
                        -URL $consoleUrl -Destination "$DIAGNOSTICS_BUILD_LOGS_DIR\console-jenkins.log"
     $remoteDirPath = Get-RemoteBuildDirectoryPath

--- a/Mesos/start-windows-build.ps1
+++ b/Mesos/start-windows-build.ps1
@@ -318,7 +318,7 @@ function New-RemoteLatestSymlinks {
 }
 
 function Start-LogServerFilesUpload {
-    $consoleUrl = "${JENKINS_URL}/job/${env:JOB_NAME}/${env:BUILD_NUMBER}/consoleText"
+    $consoleUrl = "${env:JENKINS_URL}/job/${env:JOB_NAME}/${env:BUILD_NUMBER}/consoleText"
     Start-FileDownload -User ${env:JENKINS_USER} -Password ${env:JENKINS_PASSWORD} `
                        -URL $consoleUrl -Destination "$MESOS_BUILD_LOGS_DIR\console-jenkins.log"
     $remoteDirPath = Get-RemoteBuildDirectoryPath

--- a/Metrics/start-windows-build.ps1
+++ b/Metrics/start-windows-build.ps1
@@ -256,7 +256,7 @@ function New-RemoteLatestSymlinks {
 }
 
 function Start-LogServerFilesUpload {
-    $consoleUrl = "${JENKINS_URL}/job/${env:JOB_NAME}/${env:BUILD_NUMBER}/consoleText"
+    $consoleUrl = "${env:JENKINS_URL}/job/${env:JOB_NAME}/${env:BUILD_NUMBER}/consoleText"
     Start-FileDownload -User ${env:JENKINS_USER} -Password ${env:JENKINS_PASSWORD} `
                        -URL $consoleUrl -Destination "$METRICS_BUILD_LOGS_DIR\console-jenkins.log"
     $remoteDirPath = Get-RemoteBuildDirectoryPath

--- a/Net/start-windows-build.ps1
+++ b/Net/start-windows-build.ps1
@@ -311,7 +311,7 @@ function New-RemoteLatestSymlinks {
 }
 
 function Start-LogServerFilesUpload {
-    $consoleUrl = "${JENKINS_URL}/job/${env:JOB_NAME}/${env:BUILD_NUMBER}/consoleText"
+    $consoleUrl = "${env:JENKINS_URL}/job/${env:JOB_NAME}/${env:BUILD_NUMBER}/consoleText"
     Start-FileDownload -User ${env:JENKINS_USER} -Password ${env:JENKINS_PASSWORD} `
                        -URL $consoleUrl -Destination "$DCOS_NET_BUILD_LOGS_DIR\console-jenkins.log"
     $remoteDirPath = Get-RemoteBuildDirectoryPath

--- a/Spartan/start-windows-build.ps1
+++ b/Spartan/start-windows-build.ps1
@@ -199,7 +199,7 @@ function New-RemoteSymlink {
 }
 
 function Start-LogServerFilesUpload {
-    $consoleUrl = "${JENKINS_URL}/job/${env:JOB_NAME}/${env:BUILD_NUMBER}/consoleText"
+    $consoleUrl = "${env:JENKINS_URL}/job/${env:JOB_NAME}/${env:BUILD_NUMBER}/consoleText"
     Start-FileDownload -User ${env:JENKINS_USER} -Password ${env:JENKINS_PASSWORD} `
                        -URL $consoleUrl -Destination "$SPARTAN_BUILD_LOGS_DIR\console-jenkins.log"
     $remoteDirPath = Get-RemoteBuildDirectoryPath


### PR DESCRIPTION
The environment variable `JENKINS_URL` usage has the missing `env:` when called.