### PR TITLE
Update `GenerateAgentBlob.ps1` and `PublishTestingAgentBlob.ps1`

### DIFF
--- a/AgentBlob/GenerateAgentBlob.ps1
+++ b/AgentBlob/GenerateAgentBlob.ps1
@@ -98,7 +98,7 @@ function New-DCOSWindowsAgentBlob {
         Remove-Item -Recurse -Force -Path $setupScripts
     }
     Start-ExecuteWithRetry -ScriptBlock {
-        $p = Start-Process -FilePath 'git.exe' -Wait -PassThru -NoNewWindow -ArgumentList @('clone', $DCOS_WINDOWS_GIT_URL, $setupScripts)
+        $p = Start-Process -FilePath 'git.exe' -Wait -PassThru -NoNewWindow -ArgumentList @('clone', '-q', $DCOS_WINDOWS_GIT_URL, $setupScripts)
         if($p.ExitCode -ne 0) {
             Throw "Failed to clone $DCOS_WINDOWS_GIT_URL repository"
         }

--- a/AgentBlob/PublishTestingAgentBlob.ps1
+++ b/AgentBlob/PublishTestingAgentBlob.ps1
@@ -64,7 +64,7 @@ function Publish-BuildArtifacts {
         Remove-Item -Recurse -Force $ciScripts
     }
     Start-ExecuteWithRetry -ScriptBlock {
-        $p = Start-Process -FilePath 'git.exe' -Wait -PassThru -NoNewWindow -ArgumentList @('clone', $MESOS_JENKINS_GIT_URL, $ciScripts)
+        $p = Start-Process -FilePath 'git.exe' -Wait -PassThru -NoNewWindow -ArgumentList @('clone', '-q', $MESOS_JENKINS_GIT_URL, $ciScripts)
         if($p.ExitCode -ne 0) {
             Throw "Failed to clone $MESOS_JENKINS_GIT_URL repository"
         }

--- a/AgentBlob/PublishTestingAgentBlob.ps1
+++ b/AgentBlob/PublishTestingAgentBlob.ps1
@@ -2,7 +2,8 @@ Param(
     [Parameter(Mandatory=$true)]
     [string]$ArtifactsDirectory,
     [string]$ReleaseVersion=$(Get-Date -Format "MM-dd-yyy_HH-mm-ss"),
-    [string]$ParametersFile="${env:TEMP}\publish-blob-parameters.json"
+    [string]$ParametersFile="${env:TEMP}\publish-blob-parameters.json",
+    [switch]$NewLatestSymlink
 )
 
 $ErrorActionPreference = "Stop"
@@ -75,7 +76,9 @@ function Publish-BuildArtifacts {
     $remoteBuildDir = "${REMOTE_BASE_DIR}/${ReleaseVersion}"
     New-RemoteDirectory -RemoteDirectoryPath $remoteBuildDir
     Copy-FilesToRemoteServer "${ArtifactsDirectory}\*" $remoteBuildDir
-    New-RemoteSymlink -RemotePath $remoteBuildDir -RemoteSymlinkPath "${REMOTE_BASE_DIR}/latest"
+    if($NewLatestSymlink) {
+        New-RemoteSymlink -RemotePath $remoteBuildDir -RemoteSymlinkPath "${REMOTE_BASE_DIR}/latest"
+    }
 }
 
 function New-ParametersFile {


### PR DESCRIPTION
* Add `-q` parameter when using `git clone` 
* Add the `NewLatestSymlink` switch flag used to update the latest symlink for the Windows agent blob
