### PR TITLE
Move CI init scripts fetch

### DIFF
--- a/AgentBlob/PublishTestingAgentBlob.ps1
+++ b/AgentBlob/PublishTestingAgentBlob.ps1
@@ -59,10 +59,6 @@ function Publish-BuildArtifacts {
     if((Get-ChildItem $ArtifactsDirectory).Count -eq 0) {
         Throw "The artifacts directory is empty"
     }
-    # Fetch the CI init script before publishing artifacts
-    Start-FileDownload -URL "https://raw.githubusercontent.com/dcos/dcos-windows/master/scripts/DCOSWindowsAgentSetup.ps1" `
-                       -Destination "${ArtifactsDirectory}\DCOSWindowsAgentSetup.ps1"
-    Copy-Item -Recurse -Path "$PSScriptRoot\..\DCOS\preprovision" -Destination "${ArtifactsDirectory}\preprovision"
     $remoteBuildDir = "${REMOTE_BASE_DIR}/${ReleaseVersion}"
     New-RemoteDirectory -RemoteDirectoryPath $remoteBuildDir
     Copy-FilesToRemoteServer "${ArtifactsDirectory}\*" $remoteBuildDir


### PR DESCRIPTION
This commit adds the following updates:

* Move the fetching of the `DCOSWindowsAgentSetup.ps1` and the pre-provision scripts from `PublishTestingAgentBlob.ps1` to `GenerateAgentBlob.ps1`
* Instead of individually downloading the `DCOSWindowsAgentSetup.ps1` script, we copy it from the local cloned `dcos/dcos-windows` repository
* Copy the `DCOSWindowsAgentSetup.ps1` from its new location in the `dcos/dcos-windows` repository. For now, there is a check that will copy from the old location, to maintain backwards compatibility 