### PR TITLE
Fix AgentBlob/GenerateAgentBlob.ps1

### DIFF
--- a/AgentBlob/GenerateAgentBlob.ps1
+++ b/AgentBlob/GenerateAgentBlob.ps1
@@ -110,7 +110,7 @@ function New-DCOSWindowsAgentBlob {
     Start-FileDownload -URL $dcoswindowsZipUrl -Destination $dcoswindowsArchive
     Expand-Archive -Path $dcoswindowsArchive -DestinationPath $dcoswindowsTmpDir -Force
     Remove-Item -Force -Path $dcoswindowsArchive
-    Move-Item "${dcoswindowsTmpDir}\dcos-windows-${fileName}\scripts" $setupScripts
+    Copy-Item -Recurse -Path "${dcoswindowsTmpDir}\dcos-windows-${fileName}\scripts" -Destination $setupScripts
     ###
     # TODO(ibalutoiu): For backwards compatibility we also copy the scripts file to
     #                  AGENT_BLOB_DIR\dcos-windows\scripts (the expected location atm).


### PR DESCRIPTION
Use `Copy-Item` instead of `Move-Item`.

Otherwise, the following code fails: https://github.com/Microsoft/mesos-jenkins/blob/6cb6b8e4fd134d22da75a3094aaec9c8a2fac54c/AgentBlob/GenerateAgentBlob.ps1#L130-L133

Using `Move-Item` will cause all the other lines of code to fail, if they try to copy from the previous location.