### PR TITLE
Added e2e recovery testing for windows agents

### DIFF
--- a/DCOS/utils/kill-mesos-agent.ps1
+++ b/DCOS/utils/kill-mesos-agent.ps1
@@ -1,0 +1,14 @@
+taskkill /IM mesos-agent.exe /F 2>&1 >$null
+if ($LastExitCode -eq 0) {
+    $mesosServiceObj = Get-Service dcos-mesos-slave
+    $mesosServiceObj.WaitForStatus('Running','00:01:00')
+    if ($mesosServiceObj.Status -ne 'Running') { 
+        Write-Output "FAILURE"
+    } else {
+        Write-Output "SUCCESS"
+    }
+} elseif ($LastExitCode -eq 128) {
+    Write-Output "No such process mesos-agent.exe"
+} else {
+    Write-Output "Unexpected exit code for taskkill: $LastExitCode"
+}


### PR DESCRIPTION
Added recovery testing for both private and public windows agents. We kill the mesos-agent.exe process using taskkill, then verity that the service has successfully restarted and reconnected to the same task, which is still running.