### PR TITLE
CI Fixes

### DIFF
--- a/Modules/CIUtils/CIUtils.psm1
+++ b/Modules/CIUtils/CIUtils.psm1
@@ -95,8 +95,8 @@ function Start-GitClone {
     if(Test-Path -Path $Path) {
         Remove-Item -Recurse -Force -Path $Path
     }
-    Start-ExternalCommand { git.exe clone $URL $Path } -ErrorMessage "Failed to clone the repository"
-    Start-ExternalCommand { git.exe -C $Path checkout $Branch } -ErrorMessage "Failed to checkout branch $Branch"
+    Start-ExternalCommand { git.exe clone -q $URL $Path } -ErrorMessage "Failed to clone the repository"
+    Start-ExternalCommand { git.exe -C $Path checkout -q $Branch } -ErrorMessage "Failed to checkout branch $Branch"
 }
 
 function Set-VCVariables {

--- a/Spartan/start-windows-build.ps1
+++ b/Spartan/start-windows-build.ps1
@@ -1,6 +1,6 @@
 Param(
     [Parameter(Mandatory=$false)]
-    [string]$GitURL="http://github.com/dcos/spartan",
+    [string]$GitURL="https://github.com/dcos/spartan",
     [Parameter(Mandatory=$false)]
     [string]$Branch="master",
     [Parameter(Mandatory=$false)]


### PR DESCRIPTION
Issue:  Git is writing to stderr non fatal warnings. Jenkins reports the job as failed if stderr is not empty

 - Add -q argument to git clone and git checkout commands
 - Change Spartan default git url to use https instead of http