### PR TITLE
Add graceful shutdown test for windows agents

### DIFF
--- a/DCOS/dcos-testing.sh
+++ b/DCOS/dcos-testing.sh
@@ -803,25 +803,25 @@ test_windows_agent_graceful_shutdown() {
     fi
     # eval-ing template and deleting hostname constraint -- failover impossible with constraint
     eval "cat <<-EOF
-	$(cat $WINDOWS_APP_TEMPLATE | jq -r 'del(.constraints[1])')
+	$(cat $WINDOWS_APP_CONTAINER_TEMPLATE | jq -r 'del(.constraints[1])')
 	EOF
-	" > $WINDOWS_APP_RENDERED_TEMPLATE
+	" > $WINDOWS_APP_CONTAINER_RENDERED_TEMPLATE
 
     echo "Deploying a Windows Marathon application on DC/OS"
 
-    dcos marathon app add $WINDOWS_APP_RENDERED_TEMPLATE || {
+    dcos marathon app add $WINDOWS_APP_CONTAINER_RENDERED_TEMPLATE || {
         echo "ERROR: Failed to deploy the Windows Marathon application"
         return 1
     }
     
-    local APP_NAME=$(get_marathon_application_name $WINDOWS_APP_RENDERED_TEMPLATE)
+    local APP_NAME=$(get_marathon_application_name $WINDOWS_APP_CONTAINER_RENDERED_TEMPLATE)
     
     $DIR/utils/check-marathon-app-health.py --name $APP_NAME || {
         echo "ERROR: Failed to get $APP_NAME application health checks"
         dcos marathon app show $APP_NAME > "${TEMP_LOGS_DIR}/dcos-marathon-${APP_NAME}-app-details.json"
         return 1
     }
-    local PORT=$(get_marathon_application_host_port $WINDOWS_APP_RENDERED_TEMPLATE)
+    local PORT=$(get_marathon_application_host_port $WINDOWS_APP_CONTAINER_RENDERED_TEMPLATE)
     local AGENT_HOSTNAME=$(dcos marathon app show $APP_NAME | jq -r ".tasks[0].host")
     test_dcos_task_connectivity "$APP_NAME" "$AGENT_HOSTNAME" "$AGENT_ROLE" "$PORT" || return 1
     

--- a/DCOS/dcos-testing.sh
+++ b/DCOS/dcos-testing.sh
@@ -795,13 +795,11 @@ test_windows_agent_recovery() {
 }
 
 test_windows_agent_graceful_shutdown() {
-		# test comment
-    local AGENT_HOSTNAME=""
     local AGENT_ROLE="$1"
     if [[ "${AGENT_ROLE}" == "*" ]]; then
-        local APP_ID="test-windows-graceful-shutdown-star"
+        local APP_ID="test-windows-graceful-shutdown-private-agent"
     else
-        local APP_ID="test-windows-graceful-shutdown-$(echo "${AGENT_ROLE}" | tr _ -)"
+        local APP_ID="test-windows-graceful-shutdown-public-agent"
     fi
     # eval-ing template and deleting hostname constraint -- failover impossible with constraint
     eval "cat <<-EOF
@@ -854,6 +852,7 @@ test_windows_agent_graceful_shutdown() {
 
     echo "Waiting with a timeout of 3mins for DCOS to migrate the task from $AGENT_HOSTNAME..."
     local NEW_TASK_HOST=""
+    SECONDS=0
     while true; do
         if [[ $SECONDS -gt 180 ]]; then
             echo "ERROR: task for $APP_NAME didn't migrate from $AGENT_HOSTNAME within $TIMEOUT seconds"
@@ -861,7 +860,7 @@ test_windows_agent_graceful_shutdown() {
         fi
         NEW_TASK_HOST=$(dcos marathon app show $APP_NAME | jq -r ".tasks[0].host")
         if [[ $NEW_TASK_HOST != $AGENT_HOSTNAME ]]; then
-            echo "No tasks running on $AGENT_HOSTNAME, task migrated to $NEW_TASK_HOST"    
+            echo "Task successfully migrated from $AGENT_HOSTNAME to $NEW_TASK_HOST"    
             break
         else
             sleep 1

--- a/DCOS/utils/start-mesos-service.ps1
+++ b/DCOS/utils/start-mesos-service.ps1
@@ -1,0 +1,7 @@
+$mesosServiceObj = Start-Service dcos-mesos-slave -PassThru
+$mesosServiceObj.WaitForStatus('Running','00:00:30')
+if ($mesosServiceObj.Status -ne 'Running') {
+    Write-Output "FAILURE"
+} else {
+    Write-Output "SUCCESS"
+}

--- a/DCOS/utils/stop-mesos-service.ps1
+++ b/DCOS/utils/stop-mesos-service.ps1
@@ -1,0 +1,7 @@
+$mesosServiceObj = Stop-Service dcos-mesos-slave -PassThru
+$mesosServiceObj.WaitForStatus('Stopped','00:00:30')
+if ($mesosServiceObj.Status -ne 'Stopped') { 
+    Write-Output "FAILURE"
+} else {
+    Write-Output "SUCCESS"
+}


### PR DESCRIPTION
We deploy a test application, stop the service on the windows agent that's running the task, then we wait for the task to migrate to another node (there must be at least two nodes with the same role for this) and check its health. If the task migration was successful, we start the mesos slave service back up on the initial node.