### PR TITLE
Use libwinio instead of libevent unless SSL is enabled

### DIFF
--- a/Mesos/start-windows-build.ps1
+++ b/Mesos/start-windows-build.ps1
@@ -150,9 +150,12 @@ function Start-MesosBuild {
     $logsUrl = Get-BuildLogsUrl
     try {
         $generatorName = "Visual Studio 15 2017 Win64"
-        $parameters = @("$MESOS_GIT_REPO_DIR", "-G", "`"$generatorName`"", "-T", "host=x64", "-DENABLE_LIBEVENT=ON", "-DHAS_AUTHENTICATION=ON", "-DENABLE_JAVA=ON")
+        $parameters = @("$MESOS_GIT_REPO_DIR", "-G", "`"$generatorName`"", "-T", "host=x64", "-DHAS_AUTHENTICATION=ON", "-DENABLE_JAVA=ON")
         if($EnableSSL) {
+            $parameters += "-DENABLE_LIBEVENT=ON",
             $parameters += "-DENABLE_SSL=ON"
+        } else {
+            $parameters += "-DENABLE_LIBWINIO=ON",
         }
         Start-MesosCIProcess -ProcessPath "cmake.exe" -StdoutFileName "mesos-cmake-stdout.log" -StderrFileName "mesos-cmake-stderr.log" `
                              -ArgumentList $parameters -BuildErrorMessage "Mesos failed to build."


### PR DESCRIPTION
@ionutbalutoiu This switches us to the native threading library which unblocks a myriad of tests, and should be the default. We'll eventually remove libevent support from Windows (probably after adding SSL support on top of libwinio).

Question 1: Do the Jenkins builds set `EnableSSL` to true? If so, we should disable that.
Question 2: Is this the only thing we need to change for the bits that DC/OS cluters pick up, or is there another build?