### PR TITLE
Fix Linux agents pre-provision scripts

### DIFF
--- a/DCOS/preprovision/extensions/preprovision-agent-linux-public/v1/preprovision-agent-linux-public.sh
+++ b/DCOS/preprovision/extensions/preprovision-agent-linux-public/v1/preprovision-agent-linux-public.sh
@@ -31,6 +31,28 @@ Environment=MESOS_HTTP_CREDENTIALS=/etc/ethos/dcos-mesos-agent-http-credentials
 Environment=MESOS_CREDENTIAL=/etc/ethos/dcos-mesos-agent-secret" > /etc/systemd/system/dcos-mesos-slave-public.service.d/10-dcos-mesos-agent-public-auth.conf
 
 mkdir -p /opt/azure/dcos
+
+UPDATE_CONFIG_SCRIPT="/opt/azure/dcos/update-dcos-checks-config.py"
+touch $UPDATE_CONFIG_SCRIPT
+chmod +x $UPDATE_CONFIG_SCRIPT
+cat > $UPDATE_CONFIG_SCRIPT << EOF
+#!/usr/env/bin python
+import json
+import sys
+
+CONFIG_FILE = "/opt/mesosphere/etc/dcos-check-config.json"
+
+with open(CONFIG_FILE, 'r') as f:
+    str_config = f.read()
+
+config = json.loads(str_config)
+config['node_checks']['checks'].pop('mesos_agent_registered_with_masters')
+config['node_checks']['poststart'].remove('mesos_agent_registered_with_masters')
+
+with open(CONFIG_FILE, 'w') as f:
+    f.write(json.dumps(config, sort_keys=True, indent=2))
+EOF
+
 touch /opt/azure/dcos/postinstall.sh
 chmod 744 /opt/azure/dcos/postinstall.sh
 cat > /opt/azure/dcos/postinstall.sh << EOF
@@ -43,8 +65,7 @@ systemctl disable dcos-metrics-agent.socket
 systemctl stop dcos-metrics-agent.service
 systemctl disable dcos-metrics-agent.service
 
-retrycmd_if_failure 10 10 120 curl -fsSL -o /opt/mesosphere/etc/dcos-diagnostics-runner-config.json https://dcos-mirror.azureedge.net/preprovision/dcos-diagnostics-runner-config-no-dcos-metrics.json
+python $UPDATE_CONFIG_SCRIPT
 
 systemctl restart dcos-checks-poststart.service || echo skipped
 EOF
-


### PR DESCRIPTION
The `dcos-checks-poststart` started using `dcos-check-runner` instead
of `dcos-diagnostics` since https://github.com/dcos/dcos/commit/dfdb6e436fe1f509eb845b153b30f1728a41c9ab.

This means that the `dcos-checks-poststart` systemd service uses
another configuration file for the checks. Instead of
`dcos-diagnostics-runner-config.json`, the new configuration file
is `dcos-check-config.json`.

The current dcos-engine Linux pre-provision scripts won't have
Linux healthy nodes with Mesos auth enabled, unless the new
config file is updated by removing the `mesos_agent_registered_with_masters`
check.

For a better flexibility, this commit removes the check via
a Python script, instead of fetching an already edited config file.