### PR TITLE
Fix syntax error

### DIFF
--- a/Mesos/start-windows-build.ps1
+++ b/Mesos/start-windows-build.ps1
@@ -152,10 +152,9 @@ function Start-MesosBuild {
         $generatorName = "Visual Studio 15 2017 Win64"
         $parameters = @("$MESOS_GIT_REPO_DIR", "-G", "`"$generatorName`"", "-T", "host=x64", "-DHAS_AUTHENTICATION=ON", "-DENABLE_JAVA=ON")
         if($EnableSSL) {
-            $parameters += "-DENABLE_LIBEVENT=ON",
-            $parameters += "-DENABLE_SSL=ON"
+            $parameters += @("-DENABLE_LIBEVENT=ON", "-DENABLE_SSL=ON")
         } else {
-            $parameters += "-DENABLE_LIBWINIO=ON",
+            $parameters += "-DENABLE_LIBWINIO=ON"
         }
         Start-MesosCIProcess -ProcessPath "cmake.exe" -StdoutFileName "mesos-cmake-stdout.log" -StderrFileName "mesos-cmake-stderr.log" `
                              -ArgumentList $parameters -BuildErrorMessage "Mesos failed to build."


### PR DESCRIPTION
Fix syntax error for the script `Mesos/start-windows-build.ps1`. This solves the following error in the CI:

```
At C:\Jenkins\workspace\mesos-reviewbot-testing\Mesos\start-windows-build.ps1:158 char:51
+             $parameters += "-DENABLE_LIBWINIO=ON",
+                                                   ~
Missing expression after ','.
At C:\Jenkins\workspace\mesos-reviewbot-testing\Mesos\start-windows-build.ps1:155 char:28
+             $parameters += "-DENABLE_LIBEVENT=ON",
+                            ~~~~~~~~~~~~~~~~~~~~~~~
The assignment expression is not valid. The input to an assignment operator must be an object that is able to accept 
assignments, such as a variable or a property.
    + CategoryInfo          : ParserError: (:) [], ParentContainsErrorRecordException
    + FullyQualifiedErrorId : MissingExpressionAfterToken
```