### PR TITLE
Add ungraceful shutdown test for windows agents

### DIFF
--- a/DCOS/dcos-testing.sh
+++ b/DCOS/dcos-testing.sh
@@ -973,10 +973,8 @@ test_windows_agent_ungraceful_shutdown() {
         if [[ $NEW_TASK_HOST != $AGENT_HOSTNAME ]]; then
             echo "Task successfully fail-overed from $AGENT_HOSTNAME to $NEW_TASK_HOST"    
             break
-        else
-            sleep 1
         fi
-
+        sleep 1
     done
 
     # Check task health after task failover

--- a/DCOS/dcos-testing.sh
+++ b/DCOS/dcos-testing.sh
@@ -718,6 +718,7 @@ test_dcos_windows_apps() {
     local AGENT_ROLES=("*" "slave_public")
     for ROLE in "${AGENT_ROLES[@]}"; do
         test_windows_agent_graceful_shutdown "${ROLE}" || return 1
+        test_windows_agent_ungraceful_shutdown "${ROLE}" || return 1
     done
 }
 
@@ -902,6 +903,123 @@ test_windows_agent_graceful_shutdown() {
         echo "ERROR: Service dcos-mesos-slave is in '$CHECK_RESULT' state, which is unknown"
         return 1
     fi
+}
+
+test_windows_agent_ungraceful_shutdown() {
+    local AGENT_ROLE="$1"
+    if [[ "${AGENT_ROLE}" == "*" ]]; then
+        local APP_ID="test-windows-ungraceful-shutdown-private-agent"
+    else
+        local APP_ID="test-windows-ungraceful-shutdown-public-agent"
+    fi
+    # eval-ing template and deleting hostname constraint -- failover impossible with constraint
+    eval "cat <<-EOF
+	$(cat $WINDOWS_APP_TEMPLATE | jq -r 'del(.constraints[1])')
+	EOF
+	" > $WINDOWS_APP_RENDERED_TEMPLATE
+
+    echo "Deploying a Windows Marathon application on DC/OS"
+
+    dcos marathon app add $WINDOWS_APP_RENDERED_TEMPLATE || {
+        echo "ERROR: Failed to deploy the Windows Marathon application"
+        return 1
+    }
+    
+    local APP_NAME=$(get_marathon_application_name $WINDOWS_APP_RENDERED_TEMPLATE)
+    
+    $DIR/utils/check-marathon-app-health.py --name $APP_NAME || {
+        echo "ERROR: Failed to get $APP_NAME application health checks"
+        dcos marathon app show $APP_NAME > "${TEMP_LOGS_DIR}/dcos-marathon-${APP_NAME}-app-details.json"
+        return 1
+    }
+    local PORT=$(get_marathon_application_host_port $WINDOWS_APP_RENDERED_TEMPLATE)
+    local AGENT_HOSTNAME=$(dcos marathon app show $APP_NAME | jq -r ".tasks[0].host")
+    test_dcos_task_connectivity "$APP_NAME" "$AGENT_HOSTNAME" "$AGENT_ROLE" "$PORT" || return 1
+    
+    #
+    #### Killing the service
+    #
+    setup_remote_winrm_client || return 1
+    upload_files_via_scp -i $PRIVATE_SSH_KEY_PATH -u $LINUX_ADMIN -h $MASTER_PUBLIC_ADDRESS -p "2200" -f "/tmp/kill-mesos-agent-ungraceful.ps1" "$DIR/utils/kill-mesos-agent-ungraceful.ps1" || {
+        echo "ERROR: Failed to scp kill-mesos-agent-ungraceful.ps1"
+        return 1
+    }
+    echo "Killing the dcos-mesos-slave service on $AGENT_HOSTNAME and disabling recovery options"
+    local REMOTE_CMD_STOP="/tmp/wsmancmd -H $AGENT_HOSTNAME -s -a basic -u $WIN_AGENT_ADMIN -p $WIN_AGENT_ADMIN_PASSWORD --powershell --file /tmp/kill-mesos-agent-ungraceful.ps1"
+    local CHECK_RESULT_STOP=$(run_ssh_command -i $PRIVATE_SSH_KEY_PATH -u $LINUX_ADMIN -h $MASTER_PUBLIC_ADDRESS -p "2200" -c "$REMOTE_CMD_STOP" 2>/dev/null) || {
+        echo -e "Error: Failed to run service kill script on $AGENT_HOSTNAME"
+        return 1
+    }
+
+    if [ "$CHECK_RESULT_STOP" == "SUCCESS" ]; then
+        echo "Service dcos-mesos-slave successfully Stopped!"
+    elif [ "$CHECK_RESULT_STOP" == "FAILURE" ]; then
+        echo "ERROR: Service dcos-mesos-slave stopping failure"
+        return 1
+    else
+        echo "ERROR: Service dcos-mesos-slave is in '$CHECK_RESULT' state, which is unknown"
+        return 1
+    fi
+
+    echo "Sleeping 15mins for the task to automatically fail over"
+    sleep 900
+    echo "Waiting with a timeout of 3mins for DCOS to fail the task over from $AGENT_HOSTNAME..."
+    local NEW_TASK_HOST=""
+    SECONDS=0
+    while true; do
+        if [[ $SECONDS -gt 180 ]]; then
+            echo "ERROR: task for $APP_NAME didn't migrate from $AGENT_HOSTNAME within $TIMEOUT seconds"
+            return 1
+        fi
+        NEW_TASK_HOST=$(dcos marathon app show $APP_NAME | jq -r ".tasks[0].host")
+        if [[ $NEW_TASK_HOST != $AGENT_HOSTNAME ]]; then
+            echo "Task successfully fail-overed from $AGENT_HOSTNAME to $NEW_TASK_HOST"    
+            break
+        else
+            sleep 1
+        fi
+
+    done
+
+    # Check task health after task failover
+    $DIR/utils/check-marathon-app-health.py --name $APP_NAME --ignore-last-task-failure || {
+        echo "ERROR: Failed to get $APP_NAME application health checks"
+        dcos marathon app show $APP_NAME > "${TEMP_LOGS_DIR}/dcos-marathon-${APP_NAME}-app-details.json"
+        return 1
+    }
+    test_dcos_task_connectivity "$APP_NAME" "$NEW_TASK_HOST" "$AGENT_ROLE" "$PORT" || return 1
+
+    remove_dcos_marathon_app $APP_NAME || return 1
+    
+    # Start service back up on old host
+    upload_files_via_scp -i $PRIVATE_SSH_KEY_PATH -u $LINUX_ADMIN -h $MASTER_PUBLIC_ADDRESS -p "2200" -f "/tmp/start-mesos-service.ps1" "$DIR/utils/start-mesos-service.ps1" || {
+        echo "ERROR: Failed to scp start-mesos-service.ps1"
+        return 1
+    }
+    local REMOTE_CMD_START="/tmp/wsmancmd -H $AGENT_HOSTNAME -s -a basic -u $WIN_AGENT_ADMIN -p $WIN_AGENT_ADMIN_PASSWORD --powershell --file /tmp/start-mesos-service.ps1"
+    local CHECK_RESULT_START=$(run_ssh_command -i $PRIVATE_SSH_KEY_PATH -u $LINUX_ADMIN -h $MASTER_PUBLIC_ADDRESS -p "2200" -c "$REMOTE_CMD_START" 2>/dev/null) || {
+        echo -e "Error: Failed to run service start script on $AGENT_HOSTNAME"
+        return 1
+    }
+
+    if [ "$CHECK_RESULT_START" == "SUCCESS" ]; then
+        echo "Service dcos-mesos-slave successfully started back up on $AGENT_HOSTNAME!"
+    elif [ "$CHECK_RESULT_START" == "FAILURE" ]; then
+        echo "ERROR: Service dcos-mesos-slave starting failure"
+        return 1
+    else
+        echo "ERROR: Service dcos-mesos-slave is in '$CHECK_RESULT' state, which is unknown"
+        return 1
+    fi
+
+    local TASKS=$(dcos marathon task list | grep $AGENT_HOSTNAME)
+    if [[ $TASKS == "" ]]; then
+        echo "Ungraceful shutdown and task failover is successful on $AGENT_HOSTNAME!"
+    else
+        echo "ERROR: Tasks still active on $AGENT_HOSTNAME"
+        return 1
+    fi
+
 }
 
 test_iis() {

--- a/DCOS/utils/kill-mesos-agent-ungraceful.ps1
+++ b/DCOS/utils/kill-mesos-agent-ungraceful.ps1
@@ -3,46 +3,50 @@ $mesosServiceObj.WaitForStatus('Stopped','00:00:30')
 if ($mesosServiceObj.Status -ne 'Stopped') {
     Write-Output "Failed to stop the service"
     exit 1
-} else {
-    $check = sc.exe qc dcos-mesos-slave | Select-String "--recovery_timeout=1mins"
-    if ([string]::IsNullOrEmpty($check)) {
-        $imagePath = (Get-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Services\dcos-mesos-slave' -Name ImagePath).ImagePath
-        Set-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Services\dcos-mesos-slave' -Name ImagePath -Value "$imagePath --recovery_timeout=1mins"
-    }
-    
-    $mesosServiceObjStart = Start-Service dcos-mesos-slave -PassThru
-    $mesosServiceObjStart.WaitForStatus('Running','00:00:30')
-    if ($mesosServiceObjStart.Status -ne 'Running') {
-        Write-Output "Failed to start the service back up"
-        exit 1
-    } else {
-        $check_after = (sc.exe qc dcos-mesos-slave | Select-String "--recovery_timeout=1mins" | foreach {$_.matches} | select value).Value
-        if ( $check_after -ne "--recovery_timeout=1mins") {
-            Write-Output "Recovery timeout not set to 1min"
-            exit 1
-        }
-        
-        sc.exe failure dcos-mesos-slave actions= ////// reset= 86400 2>&1 >$null
-        if ($LastExitCode -ne 0) {
-            Write-Output "Unexpected exit code for sc.exe: $LastExitCode. Aborting"
-            exit 1
-        }
-        
-        taskkill /IM mesos-agent.exe /F 2>&1 >$null
-        if ($LastExitCode -eq 0) {
-            $mesosServiceObj = Get-Service dcos-mesos-slave
-            $mesosServiceObj.WaitForStatus('Stopped','00:01:00')
-            if ($mesosServiceObj.Status -ne 'Stopped') { 
-                Write-Output "FAILURE"
-            } else {
-                Write-Output "SUCCESS"
-            }
-        } elseif ($LastExitCode -eq 128) {
-            Write-Output "No such process mesos-agent.exe"
-        } else {
-            Write-Output "Unexpected exit code for taskkill: $LastExitCode"
-        }
-    }
 }
 
+$check = sc.exe qc dcos-mesos-slave | Select-String "--recovery_timeout=1mins"
+if ($LastExitCode -ne 0) {
+    Write-Output "Unexpected exit code for sc.exe: $LastExitCode. Aborting"
+    exit 1
+}
+if ([string]::IsNullOrEmpty($check)) {
+    $imagePath = (Get-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Services\dcos-mesos-slave' -Name ImagePath).ImagePath
+    Set-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Services\dcos-mesos-slave' -Name ImagePath -Value "$imagePath --recovery_timeout=1mins"
+}
 
+$mesosServiceObjStart = Start-Service dcos-mesos-slave -PassThru
+$mesosServiceObjStart.WaitForStatus('Running','00:00:30')
+if ($mesosServiceObjStart.Status -ne 'Running') {
+    Write-Output "Failed to start the service back up"
+    exit 1
+} 
+
+$check_after = (sc.exe qc dcos-mesos-slave | Select-String "--recovery_timeout=1mins" | foreach {$_.matches} | select value).Value
+if ( $check_after -ne "--recovery_timeout=1mins") {
+    Write-Output "Recovery timeout not set to 1min"
+    exit 1
+}
+
+sc.exe failure dcos-mesos-slave actions= ////// reset= 86400 2>&1 >$null
+if ($LastExitCode -ne 0) {
+    Write-Output "Unexpected exit code for sc.exe: $LastExitCode. Aborting"
+    exit 1
+}
+
+taskkill /IM mesos-agent.exe /F 2>&1 >$null
+if ($LastExitCode -eq 0) {
+    $mesosServiceObj = Get-Service dcos-mesos-slave
+    $mesosServiceObj.WaitForStatus('Stopped','00:01:00')
+    if ($mesosServiceObj.Status -ne 'Stopped') { 
+        Write-Output "FAILURE"
+    } else {
+        Write-Output "SUCCESS"
+    }
+} elseif ($LastExitCode -eq 128) {
+    Write-Output "No such process mesos-agent.exe"
+    exit 1
+} else {
+    Write-Output "Unexpected exit code for taskkill: $LastExitCode"
+    exit 1
+}

--- a/DCOS/utils/kill-mesos-agent-ungraceful.ps1
+++ b/DCOS/utils/kill-mesos-agent-ungraceful.ps1
@@ -1,0 +1,48 @@
+$mesosServiceObj = Stop-Service dcos-mesos-slave -PassThru
+$mesosServiceObj.WaitForStatus('Stopped','00:00:30')
+if ($mesosServiceObj.Status -ne 'Stopped') {
+    Write-Output "Failed to stop the service"
+    exit 1
+} else {
+    $check = sc.exe qc dcos-mesos-slave | Select-String "--recovery_timeout=1mins"
+    if ([string]::IsNullOrEmpty($check)) {
+        $imagePath = (Get-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Services\dcos-mesos-slave' -Name ImagePath).ImagePath
+        Set-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Services\dcos-mesos-slave' -Name ImagePath -Value "$imagePath --recovery_timeout=1mins"
+    }
+    
+    $mesosServiceObjStart = Start-Service dcos-mesos-slave -PassThru
+    $mesosServiceObjStart.WaitForStatus('Running','00:00:30')
+    if ($mesosServiceObjStart.Status -ne 'Running') {
+        Write-Output "Failed to start the service back up"
+        exit 1
+    } else {
+        $check_after = (sc.exe qc dcos-mesos-slave | Select-String "--recovery_timeout=1mins" | foreach {$_.matches} | select value).Value
+        if ( $check_after -ne "--recovery_timeout=1mins") {
+            Write-Output "Recovery timeout not set to 1min"
+            exit 1
+        }
+        
+        sc.exe failure dcos-mesos-slave actions= ////// reset= 86400 2>&1 >$null
+        if ($LastExitCode -ne 0) {
+            Write-Output "Unexpected exit code for sc.exe: $LastExitCode. Aborting"
+            exit 1
+        }
+        
+        taskkill /IM mesos-agent.exe /F 2>&1 >$null
+        if ($LastExitCode -eq 0) {
+            $mesosServiceObj = Get-Service dcos-mesos-slave
+            $mesosServiceObj.WaitForStatus('Stopped','00:01:00')
+            if ($mesosServiceObj.Status -ne 'Stopped') { 
+                Write-Output "FAILURE"
+            } else {
+                Write-Output "SUCCESS"
+            }
+        } elseif ($LastExitCode -eq 128) {
+            Write-Output "No such process mesos-agent.exe"
+        } else {
+            Write-Output "Unexpected exit code for taskkill: $LastExitCode"
+        }
+    }
+}
+
+


### PR DESCRIPTION
We deploy a test application, kill the agent, disable recovery options, and wait for the task to migrate to a new host.