### PR TITLE
Fix for null variable in graceful shutdown test

### DIFF
--- a/DCOS/dcos-testing.sh
+++ b/DCOS/dcos-testing.sh
@@ -869,7 +869,7 @@ test_windows_agent_graceful_shutdown() {
             return 1
         fi
         NEW_TASK_HOST=$(dcos marathon app show $APP_NAME | jq -r ".tasks[0].host")
-        if [[ $NEW_TASK_HOST != $AGENT_HOSTNAME ]]; then
+        if [[ $NEW_TASK_HOST != $AGENT_HOSTNAME ]] && [[ ! -z $NEW_TASK_HOST ]] && [[ $NEW_TASK_HOST != "null" ]]; then
             echo "Task successfully migrated from $AGENT_HOSTNAME to $NEW_TASK_HOST"    
             break
         else


### PR DESCRIPTION
Add fix for checking that the new task host is not null in the graceful shutdown test. This happens because the DCOS API sometimes takes 2-3 seconds to report a task host change, even if the task is up & running & healthy.