### PR TITLE
Add timeout nc cmd

### DIFF
--- a/DCOS/utils/utils.sh
+++ b/DCOS/utils/utils.sh
@@ -13,7 +13,7 @@ check_open_port() {
             echo "ERROR: Port $PORT didn't open at $ADDRESS within $TIMEOUT seconds"
             return 1
         fi
-        nc -v -z "$ADDRESS" "$PORT" &>/dev/null && break || sleep 1
+        nc -w 5 -z "$ADDRESS" "$PORT" &>/dev/null && break || sleep 1
     done
 }
 


### PR DESCRIPTION
The `nc` command sometimes never finishes if the port is not open, thus making the Jenkins jobs to be stucked.

When checking if the port is open via `nc`, we let a timeout of 5 seconds.