### PR TITLE
Add '-NoNewWindow' parameter

### DIFF
--- a/Modules/CIUtils/CIUtils.psm1
+++ b/Modules/CIUtils/CIUtils.psm1
@@ -348,7 +348,7 @@ function Start-FileDownload {
         $params += '--insecure'
     }
     $params += @('-o', $Destination, $URL)
-    $p = Start-Process -FilePath 'curl.exe' -ArgumentList $params -Wait -PassThru
+    $p = Start-Process -FilePath 'curl.exe' -NoNewWindow -ArgumentList $params -Wait -PassThru
     if($p.ExitCode -ne 0) {
         Throw "Fail to download $URL"
     }


### PR DESCRIPTION
This parameter is added to `Start-Process` PowerShell cmdlet used to invoke `curl.exe` requests.