### PR TITLE
Scaling tests update: Disconnect any logged account

### DIFF
--- a/DCOS/autoscale-testing/AutoScale.Tests.ps1
+++ b/DCOS/autoscale-testing/AutoScale.Tests.ps1
@@ -30,8 +30,8 @@ function New-AzureRmSession {
         $subscription = $null
     }
     if($subscription) {
-        Write-Host "AzureRm session is already created"
-        return
+        # Disconnect any account if it's logged
+        Remove-AzureRmAccount -Confirm:$false
     }
     if(!$env:CLIENT_ID -or !$env:CLIENT_SECRET -or !$env:TENANT_ID) {
         Set-CredentialsFromEnvFile


### PR DESCRIPTION
We might not have the current logged session as the proper one.
Therefore, we disconnect any session and we connect the appropriate Azure account.