### PR TITLE
Update Linux DC/OS bootstrap URL

### DIFF
--- a/DCOS/dcos-engine-deploy.sh
+++ b/DCOS/dcos-engine-deploy.sh
@@ -30,7 +30,7 @@ validate_simple_deployment_params() {
         export DCOS_WINDOWS_BOOTSTRAP_URL="$CI_WEB_ROOT/dcos-windows/testing/windows-agent-blob/latest"
     fi
     if [[ -z $DCOS_BOOTSTRAP_URL ]]; then
-        export DCOS_BOOTSTRAP_URL="$CI_WEB_ROOT/dcos/builds/latest/dcos_generate_config.sh"
+        export DCOS_BOOTSTRAP_URL="https://downloads.dcos.io/dcos/testing/pull/2481/dcos_generate_config.sh"
     fi
 }
 


### PR DESCRIPTION
Update the default value used for the DC/OS Linux bootstrap URL.

From now on, this points to the `dcos_generate_config.sh` given by the Mesosphere DC/OS nightly builds from https://github.com/dcos/dcos/pull/2481.