### PR TITLE
Update preprovision-agent-windows-mesos-credentials.ps1

### DIFF
--- a/DCOS/preprovision/extensions/preprovision-agent-windows/v1/preprovision-agent-windows-mesos-credentials.ps1
+++ b/DCOS/preprovision/extensions/preprovision-agent-windows/v1/preprovision-agent-windows-mesos-credentials.ps1
@@ -1,6 +1,8 @@
 $ErrorActionPreference = "Stop"
 
 $MESOS_SERVICE_DIR = Join-Path $env:SystemDrive "DCOS\mesos\service"
+$MESOS_SERVICE_NAME = "dcos-mesos-slave" # TODO(ibalutoiu): To be removed once custom data execute after pre-provision scripts
+
 New-Item -ItemType Directory -Force -Path $MESOS_SERVICE_DIR
 
 $UTF8NoBOM = New-Object System.Text.UTF8Encoding $False
@@ -13,3 +15,12 @@ $httpCred = "{`"credentials`": [{`"principal`": `"mycred2`", `"secret`": `"mysec
 
 $serviceEnv = "MESOS_AUTHENTICATE_HTTP_READONLY=true`r`nMESOS_AUTHENTICATE_HTTP_READWRITE=true`r`nMESOS_HTTP_CREDENTIALS=$MESOS_SERVICE_DIR\http_credential.json`r`nMESOS_CREDENTIAL=$MESOS_SERVICE_DIR\credential.json"
 [System.IO.File]::WriteAllLines("$MESOS_SERVICE_DIR\environment-file", $serviceEnv, $UTF8NoBOM)
+
+#
+# TODO(ibalutoiu): Remove this once we have pre-provision scripts executed
+#                  before custom data.
+#
+$service = Get-Service -Name $MESOS_SERVICE_NAME -ErrorAction SilentlyContinue
+if($service) {
+    Restart-Service -Name $MESOS_SERVICE_NAME -Force -Confirm:$false
+}


### PR DESCRIPTION
At this moment, the pre-provision scripts are executed before custom data.

The `preprovision-agent-windows-mesos-credentials.ps1` script enables Mesos authentication after the Mesos agent registered without authentication. When Mesos auth is enabled on the masters, the Mesos Windows agents will disappear from the API until the service is restarted.

This commit fixes the problem described above.