### PR TITLE
Add detection of service name for private/public windows agents

### DIFF
--- a/DCOS/utils/kill-mesos-agent-ungraceful.ps1
+++ b/DCOS/utils/kill-mesos-agent-ungraceful.ps1
@@ -1,34 +1,45 @@
-$mesosServiceObj = Stop-Service dcos-mesos-slave -PassThru
+foreach($name in "dcos-mesos-slave", "dcos-mesos-slave-public") {
+    $svc = Get-Service -Name $name -ErrorAction SilentlyContinue
+    if($svc) {
+        $mesosServiceName = $name
+        break
+    }
+}
+if(!$mesosServiceName) {
+    Throw "Cannot find the Mesos slave agent"
+}
+
+$mesosServiceObj = Stop-Service $mesosServiceName -PassThru
 $mesosServiceObj.WaitForStatus('Stopped','00:00:30')
 if ($mesosServiceObj.Status -ne 'Stopped') {
     Write-Output "Failed to stop the service"
     exit 1
 }
 
-$check = sc.exe qc dcos-mesos-slave | Select-String "--recovery_timeout=1mins"
+$check = sc.exe qc $mesosServiceName | Select-String "--recovery_timeout=1mins"
 if ($LastExitCode -ne 0) {
     Write-Output "Unexpected exit code for sc.exe: $LastExitCode. Aborting"
     exit 1
 }
 if ([string]::IsNullOrEmpty($check)) {
-    $imagePath = (Get-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Services\dcos-mesos-slave' -Name ImagePath).ImagePath
-    Set-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Services\dcos-mesos-slave' -Name ImagePath -Value "$imagePath --recovery_timeout=1mins"
+    $imagePath = (Get-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Services\$mesosServiceName' -Name ImagePath).ImagePath
+    Set-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Services\$mesosServiceName' -Name ImagePath -Value "$imagePath --recovery_timeout=1mins"
 }
 
-$mesosServiceObjStart = Start-Service dcos-mesos-slave -PassThru
+$mesosServiceObjStart = Start-Service $mesosServiceName -PassThru
 $mesosServiceObjStart.WaitForStatus('Running','00:00:30')
 if ($mesosServiceObjStart.Status -ne 'Running') {
     Write-Output "Failed to start the service back up"
     exit 1
 } 
 
-$check_after = (sc.exe qc dcos-mesos-slave | Select-String "--recovery_timeout=1mins" | foreach {$_.matches} | select value).Value
+$check_after = (sc.exe qc $mesosServiceName | Select-String "--recovery_timeout=1mins" | foreach {$_.matches} | select value).Value
 if ( $check_after -ne "--recovery_timeout=1mins") {
     Write-Output "Recovery timeout not set to 1min"
     exit 1
 }
 
-sc.exe failure dcos-mesos-slave actions= ////// reset= 86400 2>&1 >$null
+sc.exe failure $mesosServiceName actions= ////// reset= 86400 2>&1 >$null
 if ($LastExitCode -ne 0) {
     Write-Output "Unexpected exit code for sc.exe: $LastExitCode. Aborting"
     exit 1
@@ -36,7 +47,7 @@ if ($LastExitCode -ne 0) {
 
 taskkill /IM mesos-agent.exe /F 2>&1 >$null
 if ($LastExitCode -eq 0) {
-    $mesosServiceObj = Get-Service dcos-mesos-slave
+    $mesosServiceObj = Get-Service $mesosServiceName
     $mesosServiceObj.WaitForStatus('Stopped','00:01:00')
     if ($mesosServiceObj.Status -ne 'Stopped') { 
         Write-Output "FAILURE"

--- a/DCOS/utils/kill-mesos-agent-ungraceful.ps1
+++ b/DCOS/utils/kill-mesos-agent-ungraceful.ps1
@@ -22,8 +22,8 @@ if ($LastExitCode -ne 0) {
     exit 1
 }
 if ([string]::IsNullOrEmpty($check)) {
-    $imagePath = (Get-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Services\$mesosServiceName' -Name ImagePath).ImagePath
-    Set-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Services\$mesosServiceName' -Name ImagePath -Value "$imagePath --recovery_timeout=1mins"
+    $imagePath = (Get-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Services\$mesosServiceName" -Name ImagePath).ImagePath
+    Set-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Services\$mesosServiceName" -Name ImagePath -Value "$imagePath --recovery_timeout=1mins"
 }
 
 $mesosServiceObjStart = Start-Service $mesosServiceName -PassThru

--- a/DCOS/utils/kill-mesos-agent.ps1
+++ b/DCOS/utils/kill-mesos-agent.ps1
@@ -1,6 +1,17 @@
+foreach($name in "dcos-mesos-slave", "dcos-mesos-slave-public") {
+    $svc = Get-Service -Name $name -ErrorAction SilentlyContinue
+    if($svc) {
+        $mesosServiceName = $name
+        break
+    }
+}
+if(!$mesosServiceName) {
+    Throw "Cannot find the Mesos slave agent"
+}
+
 taskkill /IM mesos-agent.exe /F 2>&1 >$null
 if ($LastExitCode -eq 0) {
-    $mesosServiceObj = Get-Service dcos-mesos-slave
+    $mesosServiceObj = Get-Service $mesosServiceName
     $mesosServiceObj.WaitForStatus('Running','00:01:00')
     if ($mesosServiceObj.Status -ne 'Running') { 
         Write-Output "FAILURE"

--- a/DCOS/utils/start-mesos-service.ps1
+++ b/DCOS/utils/start-mesos-service.ps1
@@ -1,4 +1,15 @@
-$mesosServiceObj = Start-Service dcos-mesos-slave -PassThru
+foreach($name in "dcos-mesos-slave", "dcos-mesos-slave-public") {
+    $svc = Get-Service -Name $name -ErrorAction SilentlyContinue
+    if($svc) {
+        $mesosServiceName = $name
+        break
+    }
+}
+if(!$mesosServiceName) {
+    Throw "Cannot find the Mesos slave agent"
+}
+
+$mesosServiceObj = Start-Service $mesosServiceName -PassThru
 $mesosServiceObj.WaitForStatus('Running','00:00:30')
 if ($mesosServiceObj.Status -ne 'Running') {
     Write-Output "FAILURE"

--- a/DCOS/utils/stop-mesos-service.ps1
+++ b/DCOS/utils/stop-mesos-service.ps1
@@ -1,4 +1,15 @@
-$mesosServiceObj = Stop-Service dcos-mesos-slave -PassThru
+foreach($name in "dcos-mesos-slave", "dcos-mesos-slave-public") {
+    $svc = Get-Service -Name $name -ErrorAction SilentlyContinue
+    if($svc) {
+        $mesosServiceName = $name
+        break
+    }
+}
+if(!$mesosServiceName) {
+    Throw "Cannot find the Mesos slave agent"
+}
+
+$mesosServiceObj = Stop-Service $mesosServiceName -PassThru
 $mesosServiceObj.WaitForStatus('Stopped','00:00:30')
 if ($mesosServiceObj.Status -ne 'Stopped') { 
     Write-Output "FAILURE"


### PR DESCRIPTION
Add detection of service name for private/public windows agents in Powershell scripts, since the naming for the windows service has changed, now being dcos-mesos-slave for private agents and dcos-mesos-slave public for public agents.