### PR TITLE
Enable core.symlinks system-wide Git config

### DIFF
--- a/Jenkins/set-up-windows-jenkins-build-server.ps1
+++ b/Jenkins/set-up-windows-jenkins-build-server.ps1
@@ -249,6 +249,10 @@ function Install-Git {
     if($LASTEXITCODE) {
         Throw "Failed to set git global config core.autocrlf true"
     }
+    git.exe config --system core.symlinks true
+    if($LASTEXITCODE) {
+        Throw "Failed to set git system config core.symlinks true"
+    }
 }
 
 function Install-CMake {


### PR DESCRIPTION
This is required when dealing with repos with symlinks (like the upsteam [dcos/dcos](https://github.com/dcos/dcos) repository).