### PR TITLE
Save logs with uft8 encoding

### DIFF
--- a/Mesos/start-windows-build.ps1
+++ b/Mesos/start-windows-build.ps1
@@ -47,7 +47,7 @@ function Start-MesosCIProcess {
         $ArgumentList | Foreach-Object { $command += " $($_ -replace '\\', '\\')" }
     }
     try {
-        cmd.exe /C "$ProcessPath $($ArgumentList -join ' ') 2>&1" | Out-File $logFile
+        cmd.exe /C "$ProcessPath $($ArgumentList -join ' ') 2>&1" | Out-File -FilePath $logFile -Encoding utf8
         if($LASTEXITCODE) {
             Throw "Failed to execute: $ProcessPath $($ArgumentList -join ' ')"
         }


### PR DESCRIPTION
The Mesos reviewbot uses a python script to post results to Reviewboard, and for now it can deal only with uft-8 encoded log files.

Signed-off-by: Ionut Balutoiu <ibalutoiu@cloudbasesolutions.com>
Co-authored-by: Alin Gabriel Serdean <aserdean@cloudbasesolutions.com>
Co-authored-by: Mihai Gheorghe <mgheorghe@cloudbasesolutions.com>