### PR TITLE
Remove useless Docker image rm

### DIFF
--- a/DCOS/preprovision/extensions/preprovision-agent-windows/v1/preprovision-agent-windows.ps1
+++ b/DCOS/preprovision/extensions/preprovision-agent-windows/v1/preprovision-agent-windows.ps1
@@ -134,11 +134,6 @@ function Start-CIAgentSetup {
     if($LASTEXITCODE -ne 0) {
         Throw "Failed to configure WinRM"
     }
-    # Remove all the cached Docker images
-    docker.exe image rm $(docker.exe image ls -q)
-    if($LASTEXITCODE) {
-        Throw "Failed to remove cached Docker images"
-    }
     # Pre-pull CI images
     $images = @(
         "microsoft/windowsservercore:1803",


### PR DESCRIPTION
We run Docker pull against all the used images in the CI. This action will update the local images if they are outdated. Having a Docker image rm for all the cached images is useless in this scenario.