### PR TITLE
Exit with 1 instead of re-throwing exception

### DIFF
--- a/DCOS/preprovision/extensions/preprovision-agent-windows/v1/preprovision-agent-windows.ps1
+++ b/DCOS/preprovision/extensions/preprovision-agent-windows/v1/preprovision-agent-windows.ps1
@@ -262,5 +262,5 @@ try {
     Write-Log "The pre-provision setup for the DC/OS Windows node failed"
     Write-Log "preprovision-agent-windows-setup.ps1 exception: $_.ToString()"
     Write-Log $_.ScriptStackTrace
-    Throw $_
+    exit 1
 }


### PR DESCRIPTION
This way, we can use `$LASTEXITCODE` for error checking in other scripts that call this `preprovision-agent-windows.ps1`. 