### PR TITLE
Fix Linux nodes health issues

### DIFF
--- a/DCOS/preprovision/extensions/preprovision-agent-linux-private/v1/preprovision-agent-linux-private.sh
+++ b/DCOS/preprovision/extensions/preprovision-agent-linux-private/v1/preprovision-agent-linux-private.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -e
 
+[[ -e /usr/bin/chmod ]] || ln -s /bin/chmod /usr/bin/chmod
+[[ -e /usr/bin/chown ]] || ln -s /bin/chown /usr/bin/chown
+
 mkdir -p /etc/ethos/
 touch /etc/ethos/dcos-mesos-agent-secret
 chmod 600 /etc/ethos/dcos-mesos-agent-secret

--- a/DCOS/preprovision/extensions/preprovision-agent-linux-public/v1/preprovision-agent-linux-public.sh
+++ b/DCOS/preprovision/extensions/preprovision-agent-linux-public/v1/preprovision-agent-linux-public.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -e
 
+[[ -e /usr/bin/chmod ]] || ln -s /bin/chmod /usr/bin/chmod
+[[ -e /usr/bin/chown ]] || ln -s /bin/chown /usr/bin/chown
+
 mkdir -p /etc/ethos/
 touch /etc/ethos/dcos-mesos-agent-secret
 chmod 600 /etc/ethos/dcos-mesos-agent-secret

--- a/DCOS/preprovision/extensions/preprovision-master-linux/v1/preprovision-master-linux.sh
+++ b/DCOS/preprovision/extensions/preprovision-master-linux/v1/preprovision-master-linux.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 
 mkdir -p /etc/ethos/
 touch /etc/ethos/dcos-mesos-master-secrets

--- a/DCOS/preprovision/extensions/preprovision-master-linux/v1/preprovision-master-linux.sh
+++ b/DCOS/preprovision/extensions/preprovision-master-linux/v1/preprovision-master-linux.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -e
 
+[[ -e /usr/bin/chmod ]] || ln -s /bin/chmod /usr/bin/chmod
+[[ -e /usr/bin/chown ]] || ln -s /bin/chown /usr/bin/chown
+
 mkdir -p /etc/ethos/
 touch /etc/ethos/dcos-mesos-master-secrets
 chmod 600 /etc/ethos/dcos-mesos-master-secrets


### PR DESCRIPTION
A recent commit into DC/OS master branch (https://github.com/dcos/dcos/commit/c140fc7702be9edcbff420e7d29ae9e4237d5c2b) introduces some `ExecStartPre=` systemd exec calls that are expecting `chmod` and `chown` to be present into `/usr/bin/` directory.