### PR TITLE
Updates for DC/OS e2e testing with Windows bootstrap node

### DIFF
--- a/DCOS/provision/extensions/preprovision-agent-linux-private/v1/preprovision-agent-linux-private-win-bootstrap-node.sh
+++ b/DCOS/provision/extensions/preprovision-agent-linux-private/v1/preprovision-agent-linux-private-win-bootstrap-node.sh
@@ -1,9 +1,6 @@
 #!/usr/bin/env bash
 set -e
 
-[[ -e /usr/bin/chmod ]] || ln -s /bin/chmod /usr/bin/chmod
-[[ -e /usr/bin/chown ]] || ln -s /bin/chown /usr/bin/chown
-
 mkdir -p /etc/ethos/
 touch /etc/ethos/dcos-mesos-agent-secret
 chmod 600 /etc/ethos/dcos-mesos-agent-secret
@@ -27,9 +24,10 @@ cat > /etc/ethos/dcos-mesos-agent-http-credentials << EOF
 }
 EOF
 
-mkdir -p /etc/systemd/system/dcos-mesos-slave.service.d
+MESOS_SYSTEMD_DIR="/etc/systemd/system/dcos-mesos-slave.service.d"
+mkdir -p $MESOS_SYSTEMD_DIR
 echo "[Service]
 Environment=MESOS_AUTHENTICATE_HTTP_READONLY=true
 Environment=MESOS_AUTHENTICATE_HTTP_READWRITE=true
 Environment=MESOS_HTTP_CREDENTIALS=/etc/ethos/dcos-mesos-agent-http-credentials
-Environment=MESOS_CREDENTIAL=/etc/ethos/dcos-mesos-agent-secret" > /etc/systemd/system/dcos-mesos-slave.service.d/10-dcos-mesos-agent-auth.conf
+Environment=MESOS_CREDENTIAL=/etc/ethos/dcos-mesos-agent-secret" > $MESOS_SYSTEMD_DIR/10-dcos-mesos-agent-auth.conf

--- a/DCOS/provision/extensions/preprovision-agent-linux-private/v1/preprovision-agent-linux-private.sh
+++ b/DCOS/provision/extensions/preprovision-agent-linux-private/v1/preprovision-agent-linux-private.sh
@@ -1,9 +1,6 @@
 #!/usr/bin/env bash
 set -e
 
-[[ -e /usr/bin/chmod ]] || ln -s /bin/chmod /usr/bin/chmod
-[[ -e /usr/bin/chown ]] || ln -s /bin/chown /usr/bin/chown
-
 mkdir -p /etc/ethos/
 touch /etc/ethos/dcos-mesos-agent-secret
 chmod 600 /etc/ethos/dcos-mesos-agent-secret
@@ -27,12 +24,13 @@ cat > /etc/ethos/dcos-mesos-agent-http-credentials << EOF
 }
 EOF
 
-mkdir -p /etc/systemd/system/dcos-mesos-slave.service.d
+MESOS_SYSTEMD_DIR="/etc/systemd/system/dcos-mesos-slave.service.d"
+mkdir -p $MESOS_SYSTEMD_DIR
 echo "[Service]
 Environment=MESOS_AUTHENTICATE_HTTP_READONLY=true
 Environment=MESOS_AUTHENTICATE_HTTP_READWRITE=true
 Environment=MESOS_HTTP_CREDENTIALS=/etc/ethos/dcos-mesos-agent-http-credentials
-Environment=MESOS_CREDENTIAL=/etc/ethos/dcos-mesos-agent-secret" > /etc/systemd/system/dcos-mesos-slave.service.d/10-dcos-mesos-agent-auth.conf
+Environment=MESOS_CREDENTIAL=/etc/ethos/dcos-mesos-agent-secret" > $MESOS_SYSTEMD_DIR/10-dcos-mesos-agent-auth.conf
 
 mkdir -p /opt/azure/dcos
 

--- a/DCOS/provision/extensions/preprovision-agent-linux-public/v1/preprovision-agent-linux-public-win-bootstrap-node.sh
+++ b/DCOS/provision/extensions/preprovision-agent-linux-public/v1/preprovision-agent-linux-public-win-bootstrap-node.sh
@@ -1,9 +1,6 @@
 #!/usr/bin/env bash
 set -e
 
-[[ -e /usr/bin/chmod ]] || ln -s /bin/chmod /usr/bin/chmod
-[[ -e /usr/bin/chown ]] || ln -s /bin/chown /usr/bin/chown
-
 mkdir -p /etc/ethos/
 touch /etc/ethos/dcos-mesos-agent-secret
 chmod 600 /etc/ethos/dcos-mesos-agent-secret
@@ -27,9 +24,10 @@ cat > /etc/ethos/dcos-mesos-agent-http-credentials << EOF
 }
 EOF
 
-mkdir -p /etc/systemd/system/dcos-mesos-slave-public.service.d
+MESOS_SYSTEMD_DIR="/etc/systemd/system/dcos-mesos-slave-public.service.d"
+mkdir -p $MESOS_SYSTEMD_DIR
 echo "[Service]
 Environment=MESOS_AUTHENTICATE_HTTP_READONLY=true
 Environment=MESOS_AUTHENTICATE_HTTP_READWRITE=true
 Environment=MESOS_HTTP_CREDENTIALS=/etc/ethos/dcos-mesos-agent-http-credentials
-Environment=MESOS_CREDENTIAL=/etc/ethos/dcos-mesos-agent-secret" > /etc/systemd/system/dcos-mesos-slave-public.service.d/10-dcos-mesos-agent-public-auth.conf
+Environment=MESOS_CREDENTIAL=/etc/ethos/dcos-mesos-agent-secret" > $MESOS_SYSTEMD_DIR/10-dcos-mesos-agent-auth.conf

--- a/DCOS/provision/extensions/preprovision-agent-linux-public/v1/preprovision-agent-linux-public.sh
+++ b/DCOS/provision/extensions/preprovision-agent-linux-public/v1/preprovision-agent-linux-public.sh
@@ -1,9 +1,6 @@
 #!/usr/bin/env bash
 set -e
 
-[[ -e /usr/bin/chmod ]] || ln -s /bin/chmod /usr/bin/chmod
-[[ -e /usr/bin/chown ]] || ln -s /bin/chown /usr/bin/chown
-
 mkdir -p /etc/ethos/
 touch /etc/ethos/dcos-mesos-agent-secret
 chmod 600 /etc/ethos/dcos-mesos-agent-secret
@@ -27,12 +24,13 @@ cat > /etc/ethos/dcos-mesos-agent-http-credentials << EOF
 }
 EOF
 
-mkdir -p /etc/systemd/system/dcos-mesos-slave-public.service.d
+MESOS_SYSTEMD_DIR="/etc/systemd/system/dcos-mesos-slave-public.service.d"
+mkdir -p $MESOS_SYSTEMD_DIR
 echo "[Service]
 Environment=MESOS_AUTHENTICATE_HTTP_READONLY=true
 Environment=MESOS_AUTHENTICATE_HTTP_READWRITE=true
 Environment=MESOS_HTTP_CREDENTIALS=/etc/ethos/dcos-mesos-agent-http-credentials
-Environment=MESOS_CREDENTIAL=/etc/ethos/dcos-mesos-agent-secret" > /etc/systemd/system/dcos-mesos-slave-public.service.d/10-dcos-mesos-agent-public-auth.conf
+Environment=MESOS_CREDENTIAL=/etc/ethos/dcos-mesos-agent-secret" > $MESOS_SYSTEMD_DIR/10-dcos-mesos-agent-auth.conf
 
 mkdir -p /opt/azure/dcos
 

--- a/DCOS/scalability-testing/Scalability.Tests.ps1
+++ b/DCOS/scalability-testing/Scalability.Tests.ps1
@@ -256,11 +256,35 @@ Describe "Scale up check" {
     $skipFlag = $mesosAuth
 
     It "Are all nodes healthy" -Skip:$skipFlag {
-        Confirm-DCOSAgentsHealth -ResourceGroupName $env:RESOURCE_GROUP | Should be $true
+        # Allow the agents a 10 minutes timeout to become healthy after scale-up
+        $retryCount = 20
+        do {
+            $agentsGoodHealth = Confirm-DCOSAgentsHealth -ResourceGroupName $env:RESOURCE_GROUP
+            if($agentsGoodHealth) {
+                Write-Host "The agents are in good health now!"
+                break
+            }
+            Write-Host "The agents are not in good health yet. Retry count=$retryCount"
+            Start-Sleep -Seconds 30
+            $retryCount -= 1
+        } while($retryCount -gt 0)
+        $agentsGoodHealth | Should be $true
     }
 
     It "Are all nodes metric service running fine" -Skip:$skipFlag {
-        Confirm-DCOSAgentsGoodMetrics -ResourceGroupName $env:RESOURCE_GROUP | Should be $true
+        # Allow the agents metrics a 10 minutes timeout to become healthy after scale-up
+        $retryCount = 20
+        do {
+            $agentsGoodMetrics = Confirm-DCOSAgentsGoodMetrics -ResourceGroupName $env:RESOURCE_GROUP
+            if($agentsGoodMetrics) {
+                Write-Host "The agents have good metrics now!"
+                break
+            }
+            Write-Host "The agents don't have good metrics yet. Retry count=$retryCount"
+            Start-Sleep -Seconds 30
+            $retryCount -= 1
+        } while($retryCount -gt 0)
+        $agentsGoodMetrics | Should be $true
     }
 }
 
@@ -318,10 +342,34 @@ Describe "Scale down check" {
     $skipFlag = $mesosAuth
 
     It "Are all nodes healthy" -Skip:$skipFlag {
-        Confirm-DCOSAgentsHealth -ResourceGroupName $env:RESOURCE_GROUP | Should be $true
+        # Allow the agents a 10 minutes timeout to become healthy after scale-down
+        $retryCount = 20
+        do {
+            $agentsGoodHealth = Confirm-DCOSAgentsHealth -ResourceGroupName $env:RESOURCE_GROUP
+            if($agentsGoodHealth) {
+                Write-Host "Agents are in good health now!"
+                break
+            }
+            Write-Host "Agents are not yet in good health. Retry count=$retryCount"
+            Start-Sleep -Seconds 30
+            $retryCount -= 1
+        } while($retryCount -gt 0)
+        $agentsGoodHealth | Should be $true
     }
 
     It "Are all nodes metric service running fine" -Skip:$skipFlag {
-        Confirm-DCOSAgentsGoodMetrics -ResourceGroupName $env:RESOURCE_GROUP | Should be $true
+        # Allow the agents metrics a 10 minutes timeout to become healthy after scale-down
+        $retryCount = 20
+        do {
+            $agentsGoodMetrics = Confirm-DCOSAgentsGoodMetrics -ResourceGroupName $env:RESOURCE_GROUP
+            if($agentsGoodMetrics) {
+                Write-Host "The agents have good metrics now!"
+                break
+            }
+            Write-Host "The agents don't have good metrics yet. Retry count=$retryCount"
+            Start-Sleep -Seconds 30
+            $retryCount -= 1
+        } while($retryCount -gt 0)
+        $agentsGoodMetrics | Should be $true
     }
 }

--- a/DCOS/templates/dcos-engine/hybrid-win-bootstrap-node.json
+++ b/DCOS/templates/dcos-engine/hybrid-win-bootstrap-node.json
@@ -130,14 +130,14 @@
         "version": "v1",
         "extensionParameters": "parameters",
         "rootURL": "https://dcosci.blob.core.windows.net/provision",
-        "script": "preprovision-agent-linux-private-win-bootstrap-node.sh"
+        "script": "preprovision-agent-linux-public-win-bootstrap-node.sh"
       },
       {
         "name": "preprovision-agent-linux-private",
         "version": "v1",
         "extensionParameters": "parameters",
         "rootURL": "https://dcosci.blob.core.windows.net/provision",
-        "script": "preprovision-agent-linux-public-win-bootstrap-node.sh"
+        "script": "preprovision-agent-linux-private-win-bootstrap-node.sh"
       },
       {
         "name": "postinstall-agent-linux",


### PR DESCRIPTION
* Allow a timeout for health checks post scale up/down scenarios
* Cleanup Linux preprovision scripts
* Fix hybrid-win-bootstrap-node.json pre-provision scripts