### PR TITLE
Fix Mesos env file encoding

### DIFF
--- a/DCOS/provision/extensions/preprovision-agent-windows/v1/preprovision-agent-windows-win-bootstrap-node.ps1
+++ b/DCOS/provision/extensions/preprovision-agent-windows/v1/preprovision-agent-windows-win-bootstrap-node.ps1
@@ -278,7 +278,7 @@ function Write-MesosSecretFiles {
         "`$env:MESOS_HTTP_CREDENTIALS=`"$MESOS_CREDENTIALS_DIR\http_credential.json`"",
         "`$env:MESOS_CREDENTIAL=`"$MESOS_CREDENTIALS_DIR\credential.json`""
     )
-    Set-Content -Path "$MESOS_CREDENTIALS_DIR\auth-env.ps1" -Value $serviceEnv -Encoding utf8
+    Set-Content -Path "$MESOS_CREDENTIALS_DIR\auth-env.ps1" -Value $serviceEnv -Encoding "default"
 }
 
 try {

--- a/DCOS/provision/extensions/preprovision-agent-windows/v1/preprovision-agent-windows.ps1
+++ b/DCOS/provision/extensions/preprovision-agent-windows/v1/preprovision-agent-windows.ps1
@@ -279,7 +279,7 @@ function Write-MesosSecretFiles {
         "MESOS_HTTP_CREDENTIALS=$MESOS_ETC_SERVICE_DIR\http_credential.json",
         "MESOS_CREDENTIAL=$MESOS_ETC_SERVICE_DIR\credential.json"
     )
-    Set-Content -Path "${MESOS_ETC_SERVICE_DIR}\environment-file" -Value $serviceEnv -Encoding utf8
+    Set-Content -Path "${MESOS_ETC_SERVICE_DIR}\environment-file" -Value $serviceEnv -Encoding "default"
 }
 
 try {


### PR DESCRIPTION
The Mesos environment file passed to the service wrapper must have the system's default encoding.