### PR TITLE
Bump Docker version

### DIFF
--- a/DCOS/templates/dcos-engine/hybrid-win-bootstrap-node.json
+++ b/DCOS/templates/dcos-engine/hybrid-win-bootstrap-node.json
@@ -8,7 +8,8 @@
         "bootstrapURL": "${DCOS_BOOTSTRAP_URL}"
       },
       "windowsBootstrapProfile": {
-        "bootstrapURL": "${DCOS_WINDOWS_BOOTSTRAP_URL}"
+        "bootstrapURL": "${DCOS_WINDOWS_BOOTSTRAP_URL}",
+        "dockerVersion": "18.03.1-ee-3"
       }
     },
     "masterProfile": {


### PR DESCRIPTION
Use the latest Docker EE version into testing DC/OS Windows clusters.