### PR TITLE
Add retry to dcos-metrics Stop-Service

### DIFF
--- a/DCOS/provision/extensions/postinstall-agent-windows/v1/postinstall-agent-windows.ps1
+++ b/DCOS/provision/extensions/postinstall-agent-windows/v1/postinstall-agent-windows.ps1
@@ -90,7 +90,7 @@ Start-Service $serviceName
 #
 # Disable dcos-metrics agent
 #
-Stop-Service -Force "dcos-metrics-agent.service"
+Start-ExecuteWithRetry { Stop-Service -Force "dcos-metrics-agent.service" }
 sc.exe delete "dcos-metrics-agent.service"
 if($LASTEXITCODE) {
     Throw "Failed to delete dcos-metrics-agent.service"


### PR DESCRIPTION
The dcos-metrics agent is constantly flipping between stopped / running
when Mesos auth is enabled.

Sometimes, the Stop-Service will fail if the service is stopped
into a flipping state even though the service is successfully stopped.
Adding a retry will solve this.