### PR TITLE
Fix LASTEXITCODES for powershell scripts

### DIFF
--- a/Diagnostics/start-windows-build.ps1
+++ b/Diagnostics/start-windows-build.ps1
@@ -149,7 +149,7 @@ function Start-DCOSDiagnosticsBuild {
     try {
         Start-DiagnosticsCIProcess  -ProcessPath "powershell.exe" `
                                     -LogFileName "diagnostics-build.log" `
-                                    -ArgumentList @(".\scripts\make.ps1", "build") `
+                                    -ArgumentList @("-Command", "`"& .\scripts\make.ps1 build ; exit `$LASTEXITCODE`"") `
                                     -BuildErrorMessage "Diagnostics failed to build."
     } finally {
         Pop-Location
@@ -277,7 +277,7 @@ function Start-DCOSDiagnosticsUnitTests {
     try {
         Start-DiagnosticsCIProcess  -ProcessPath "powershell.exe" `
                                     -LogFileName "diagnostics-unitests.log" `
-                                    -ArgumentList @(".\scripts\make.ps1", "test") `
+                                    -ArgumentList @("-Command", "`"& .\scripts\make.ps1 test ; exit `$LASTEXITCODE`"") `
                                     -BuildErrorMessage "Diagnostics failed to build."
     } finally {
         Pop-Location

--- a/Metrics/start-windows-build.ps1
+++ b/Metrics/start-windows-build.ps1
@@ -151,7 +151,7 @@ function Start-DCOSMetricsBuild {
         New-Item -ItemType directory -Path ".\build" -Force
         Start-MetricsCIProcess  -ProcessPath "powershell.exe" `
                                 -LogFileName "metrics-build.log" `
-                                -ArgumentList @(".\scripts\build.ps1", "collector") `
+                                -ArgumentList @("-Command", "`"& .\scripts\build.ps1 collector ; exit `$LASTEXITCODE`"") `
                                 -BuildErrorMessage "Metrics failed to build."
         Start-ExternalCommand { & go.exe get .\... } -ErrorMessage "Failed to setup the dependent packages"
         Copy-Item -Path "$METRICS_GIT_REPO_DIR\build\collector\dcos-metrics-collector-*" -Destination "$METRICS_GIT_REPO_DIR/dcos-metrics.exe"
@@ -290,7 +290,7 @@ function Start-DCOSMetricsUnitTests {
     try {
         Start-MetricsCIProcess  -ProcessPath "powershell.exe" `
                                 -LogFileName "metrics-unitests.log" `
-                                -ArgumentList @(".\scripts\test.ps1", "collector unit") `
+                                -ArgumentList @("-Command", "`"& .\scripts\test.ps1 collector unit ; exit `$LASTEXITCODE`"") `
                                 -BuildErrorMessage "Metrics unittests failed."
     } finally {
         Pop-Location


### PR DESCRIPTION
Tests that are started with powershell and fail do not throw errors.
This PR fixes this issue

metrics-testing FAILURE will be resolved after the following is merged:
https://github.com/dcos/dcos-metrics/pull/166