### PR TITLE
Remove e2e and buildBlob from Jenkinsfile

### DIFF
--- a/DCOS/Jenkinsfile
+++ b/DCOS/Jenkinsfile
@@ -25,38 +25,6 @@ def runBuild(String buildContext, String nodeName, Closure<Void> task) {
     }
 }
 
-// Linux environment for dcos e2e test
-def dcos_e2e_testing_env(String command) {
-    withCredentials([usernamePassword(credentialsId: '8d70c82f-6959-49ad-a553-e7906ad47710',
-                                      passwordVariable: 'JENKINS_PASSWORD', 
-                                      usernameVariable: 'JENKINS_USER'),
-                     usernamePassword(credentialsId: 'e20c9faa-1d51-46fa-8e69-a027c7f3f8c8',
-                                      passwordVariable: 'AZURE_SERVICE_PRINCIPAL_PASSWORD',
-                                      usernameVariable: 'AZURE_SERVICE_PRINCIPAL_ID'),
-                     usernamePassword(credentialsId: '49dc70d1-13d5-4b52-8944-d62f5a2474e3',
-                                      passwordVariable: 'DOCKER_HUB_USER_PASSWORD',
-                                      usernameVariable: 'DOCKER_HUB_USER')]) {
-    withEnv(["DCOS_WINDOWS_BOOTSTRAP_URL=http://dcos-win.westus2.cloudapp.azure.com/dcos-windows/testing/windows-agent-blob/${JOB_NAME}-${BUILD_ID}",
-             "AUTOCLEAN=true",
-             "SET_CLEANUP_TAG=true",
-             "AZURE_KEYVAULT_NAME=ci-secrets",
-             "PRIVATE_KEY_SECRET_NAME=jenkins-ssh-private-key",
-             "PUBLIC_KEY_SECRET_NAME=jenkins-ssh-public-key",
-             "WIN_PASS_SECRET_NAME=jenkins-win-pass",
-             "AZURE_REGION=westus2",
-             "WIN_AGENT_SIZE=Standard_D2s_v3",
-             "LINUX_MASTER_SIZE=Standard_D2s_v3",
-             "LINUX_AGENT_SIZE=Standard_D2s_v3",
-             "AZURE_SERVICE_PRINCIPAL_TENAT=72f988bf-86f1-41af-91ab-2d7cd011db47",
-             "DCOS_DEPLOY_DIR=$WORKSPACE/dcos-deploy-dir",
-             "JOB_ARTIFACTS_DIR=$HOME/artifacts/$JOB_NAME",
-             "AZURE_CONFIG_DIR=$WORKSPACE/azure_$BUILD_ID"]) {
-                println "Bash shell executes -> $command"
-                sh command
-             }
-        }
-}
-
 // Windows Environment for running powershell scripts
 def win_env(String command) {
     withCredentials([file(credentialsId: 'ae8d8ce4-a601-4e1b-9b53-4bb117fc3451', variable: 'SSH_KEY'),
@@ -73,28 +41,13 @@ def PowerShellWrapper(psCmd) {
     bat "powershell.exe -NonInteractive -ExecutionPolicy Bypass -Command \"\$ErrorActionPreference='Stop';[Console]::OutputEncoding=[System.Text.Encoding]::UTF8;$psCmd;EXIT \$global:LastExitCode\""
 }
 
-def e2eTesting = { dcos_e2e_testing_env('mesos-jenkins/DCOS/start-dcos-e2e-testing.sh') }
 def buildDiagnostics = { win_env('mesos-jenkins/Diagnostics/start-windows-build.ps1') }
 def buildMesos = { win_env(" \$newPath = \$env:Path -split ';' | Where-Object { \$_ -ne 'C:\\Program Files\\msys2\\usr\\bin\' } ; \$env:Path = \$newPath -join ';' ; & mesos-jenkins/Mesos/start-windows-build.ps1") }
 def buildNet = { win_env('mesos-jenkins/Net/start-windows-build.ps1') }
 def buildMetrics = { win_env('mesos-jenkins/Metrics/start-windows-build.ps1') }
-def buildBlob = { win_env("""
-    mesos-jenkins/AgentBlob/GenerateAgentBlob.ps1 
-        -DiagnosticsPackageUrl ${DIAGNOSTICS_PACKAGE_URL} 
-        -MetricsPackageUrl ${METRICS_PACKAGE_URL} 
-        -MesosPackageUrl ${MESOS_PACKAGE_URL} 
-        -DcosNetPackageUrl ${DCOS_NET_PACKAGE_URL} ; 
-    if(\$LASTEXITCODE) { exit 1 } ;
-    & mesos-jenkins/AgentBlob/PublishTestingAgentBlob.ps1 
-        -ArtifactsDirectory $WORKSPACE/artifacts 
-        -ReleaseVersion ${JOB_NAME}-${BUILD_ID}
-    """) }
 
 // Pipeline Main script
 parallel "Diagnostics build" : { runBuild('jenkins/diagnostics-testing', 'windows-build-server',   buildDiagnostics) },
          "Net build" :         { runBuild('jenkins/net-testing',         'windows-build-server',   buildNet) },
          "Mesos build" :       { runBuild('jenkins/mesos-testing',       'windows-build-server',   buildMesos) }, 
          "Metrics build" :     { runBuild('jenkins/metrics-testing',     'windows-build-server',   buildMetrics) }
-
-if (currentBuild.result == null) { runBuild('jenkins/GenerateAgentBlob',         'windows-build-server',   buildBlob) }
-if (currentBuild.result == null) { runBuild('jenkins/e2e-testing',               'dummy-slave',            e2eTesting) }


### PR DESCRIPTION
These are testing DC/OS deployments without Pkgpanda that are removed from dcos-engine.