### PR TITLE
Add test case for DC/OS upgrade.

### DIFF
--- a/DCOS/dcos-engine-deploy.sh
+++ b/DCOS/dcos-engine-deploy.sh
@@ -32,6 +32,9 @@ validate_deployment_params() {
     if [[ -z $DCOS_BOOTSTRAP_URL ]]; then
         export DCOS_BOOTSTRAP_URL="https://dcosci.blob.core.windows.net/dcos/testing/master/dcos_generate_config.sh"
     fi
+    if [[ -z $STABLE_DCOS_BOOTSTRAP_URL ]]; then
+        export STABLE DCOS_BOOTSTRAP_URL="https://dcosci.blob.core.windows.net/dcos-windows/stable/dcos_generate_config.windows.tar.xz"
+    fi
 }
 
 validate_prerequisites() {

--- a/DCOS/templates/dcos-engine/hybrid-win-bootstrap-node.json
+++ b/DCOS/templates/dcos-engine/hybrid-win-bootstrap-node.json
@@ -4,11 +4,8 @@
     "orchestratorProfile": {
       "orchestratorType": "DCOS",
       "orchestratorRelease": "1.11",
-      "linuxBootstrapProfile": {
-        "bootstrapURL": "${DCOS_BOOTSTRAP_URL}"
-      },
       "windowsBootstrapProfile": {
-        "bootstrapURL": "${DCOS_WINDOWS_BOOTSTRAP_URL}",
+        "bootstrapURL": "${STABLE_DCOS_WINDOWS_BOOTSTRAP_URL}",
         "dockerVersion": "18.03.1-ee-3"
       }
     },


### PR DESCRIPTION
- This PR adds a test case for the `dcos-engine upgrade` command: we upgrade the cluster from the stable Windows bootstrap URL to the testing Windows bootstrap URL, but we keep the same DC/OS version.