### PR TITLE
Bump Docker to 18.03.1-ee-4

### DIFF
--- a/DCOS/templates/dcos-engine/hybrid.json
+++ b/DCOS/templates/dcos-engine/hybrid.json
@@ -4,6 +4,7 @@
     "orchestratorProfile": {
       "orchestratorType": "DCOS",
       "windowsBootstrapProfile": {
+        "dockerVersion": "18.03.1-ee-4",
         "bootstrapURL": "${STABLE_DCOS_WINDOWS_BOOTSTRAP_URL}"
       }
     },


### PR DESCRIPTION
Docker released enterprise version 4 for the `18.03.1`. This pull request explicitly set this version into DC/OS e2e testing clusters.