### PR TITLE
Ignore failed tasks by default

### DIFF
--- a/DCOS/utils/check-marathon-app-health.py
+++ b/DCOS/utils/check-marathon-app-health.py
@@ -12,7 +12,7 @@ def parse_parameters():
     parser.add_argument("-n", "--name", type=str, required=True,
                         help="The DCOS application name")
     parser.add_argument("--ignore-last-task-failure", action='store_true',
-                        required=False, default=False, help="Flag to ignore"
+                        required=False, default=True, help="Flag to ignore"
                         "last task failure, used for recovery testing")
     return parser.parse_args()
 


### PR DESCRIPTION
Recently, there are a lot of these Docker transient errors when spawning
the first task:
```
Failed to run docker container: User defined networks require Docker version 1.9.0 or higher
```
This is not consistent and it's happening only when trying to spawn
the first task, while second one will work.